### PR TITLE
Add support for training from scratch

### DIFF
--- a/coco_df.py
+++ b/coco_df.py
@@ -3,9 +3,6 @@ import numpy as np
 import pandas as pd
 import skimage.io as io
 
-from constants import COCO_TRAIN_ANNOT_PATH
-from constants import COCO_VAL_ANNOT_PATH
-
 def get_meta(coco):
     ids = list(coco.imgs.keys())
     for i, img_id in enumerate(ids):
@@ -52,9 +49,9 @@ def convert_to_df(coco, data_set):
     
     return images_df, persons_df
 
-def get_df():
-    train_coco = COCO(COCO_TRAIN_ANNOT_PATH) # load annotations for training set
-    val_coco = COCO(COCO_VAL_ANNOT_PATH) # load annotations for validation set
+def get_df(path_to_train_anns, path_to_val_anns):
+    train_coco = COCO(path_to_train_anns) # load annotations for training set
+    val_coco = COCO(path_to_val_anns) # load annotations for validation set
     images_df, persons_df = convert_to_df(train_coco, 'train2017')     
     train_coco_df = pd.merge(images_df, persons_df, right_index=True, left_index=True)
     train_coco_df['source'] = 0

--- a/constants.py
+++ b/constants.py
@@ -1,14 +1,29 @@
 # Number of joints to detect
 num_classes = 16 #TODO change to 17 after verifying model
 num_hg_default = 4 # NOTE in their final design, 8 were used
+
+# Model Defaults
+DEFAULT_NUM_HG = 4 # NOTE in their final design, 8 were used
+DEFAULT_EPOCHS = 40
+DEFAULT_MODEL_PATH = 'models'
+DEFAULT_LOGS_PATH = 'logs'
+DEFAULT_OUTPUT_PATH = 'output'
+DEFAULT_TRAIN_IMG_PATH = 'data/coco/train2017'
+DEFAULT_VAL_IMG_PATH = 'data/coco/val2017'
+DEFAULT_TRAIN_ANNOT_PATH = 'data/annotations/person_keypoints_train2017.json'
+DEFAULT_VAL_ANNOT_PATH = 'data/annotations/person_keypoints_val2017.json'
+
+# Model parameters
 INPUT_DIM = (256,256)
 OUTPUT_DIM = (64,64)
 
 # Data Generator Constants
 DEFAULT_BATCH_SIZE = 10 #NOTE need to test optimal batch size
-NUM_COCO_KEYPOINTS = 17
+NUM_COCO_KEYPOINTS = 17 # Number of joints to detect
 NUM_COCO_KP_ATTRBS = 3 # (x,y,v) * 17 keypoints
 
 # COCO DF Constants
 COCO_TRAIN_ANNOT_PATH = '/content/gdrive/My Drive/COCO/2017/annotations/person_keypoints_train2017.json'
 COCO_VAL_ANNOT_PATH = '/content/gdrive/My Drive/COCO/2017/annotations/person_keypoints_val2017.json'
+
+# COCO 

--- a/data_generator.py
+++ b/data_generator.py
@@ -12,9 +12,12 @@ import skimage.io as io
 import tensorflow as tf
 from tensorflow.keras.utils import Sequence
 
-from constants import DEFAULT_BATCH_SIZE
-from constants import NUM_COCO_KEYPOINTS
-from constants import NUM_COCO_KP_ATTRBS
+from constants import *
+
+# TODO:
+# make heatmap at full resolution and then downscale to reduce issue of heat map centering
+# bounding box + x percent size (maybe 130% of bounding box size), and then varied through data augmentation 110% to 150%?
+
 
 class DataGenerator(Sequence): # inherit from Sequence to access multicore functionality: https://stanford.edu/~shervine/blog/keras-how-to-generate-data-on-the-fly
 

--- a/data_generator.py
+++ b/data_generator.py
@@ -21,8 +21,8 @@ from constants import *
 
 class DataGenerator(Sequence): # inherit from Sequence to access multicore functionality: https://stanford.edu/~shervine/blog/keras-how-to-generate-data-on-the-fly
 
-  def __init__(self, csv_file, base_dir, input_dim, output_dim, num_hg_blocks, shuffle=False, batch_size=DEFAULT_BATCH_SIZE, online_fetch=False):
-    self.df = pd.read_csv(csv_file) # csv with df of the the annotations we want, we may eventually want to pass in df instead
+  def __init__(self, df, base_dir, input_dim, output_dim, num_hg_blocks, shuffle=False, batch_size=DEFAULT_BATCH_SIZE, online_fetch=False):
+    self.df = df                    # df of the the annotations we want
     self.base_dir = base_dir        # where to read imgs from in collab runtime
     self.input_dim = input_dim      # model requirement for input image dimensions
     self.output_dim = output_dim    # dimesnions of output heatmap of model
@@ -51,7 +51,7 @@ class DataGenerator(Sequence): # inherit from Sequence to access multicore funct
     return new_img, cropped_width, cropped_height, new_bbox[0], new_bbox[1]
   
   def transform_bbox(self,bbox):
-    x,y,w,h = [round(i) for i in list(map(float,(bbox.strip('][').split(', '))))] # (x,y,w,h) anchored to top left
+    x,y,w,h = [round(i) for i in bbox] # (x,y,w,h) anchored to top left
     center_x = int(x+w/2)
     center_y = int(y+h/2)
     new_w = w if w >= h else round(h * self.input_dim[0]/self.input_dim[1])
@@ -61,7 +61,7 @@ class DataGenerator(Sequence): # inherit from Sequence to access multicore funct
     return (new_x,new_y,new_x+new_w,new_y+new_h)
 
   def transform_label(self,label, cropped_width, cropped_height,anchor_x,anchor_y):
-    label = [int(v) for v in label.strip('][').split(', ')]
+    label = [int(v) for v in label]
     # adjust x/y coords to new resized img
     transformed_label = []
     for x, y, v in zip(*[iter(label)]*3):

--- a/hourglass.py
+++ b/hourglass.py
@@ -3,14 +3,17 @@ import os
 
 import numpy as np
 import scipy.misc
-from keras.callbacks import CSVLogger, ModelCheckpoint
+from keras.callbacks import CSVLogger, ModelCheckpoint, TensorBoard, LearningRateScheduler
 from keras.losses import mean_squared_error
 from keras.models import load_model, model_from_json
 from keras.optimizers import Adam, RMSprop
 
 from hourglass_blocks import (bottleneck_block, bottleneck_mobile,
                               create_hourglass_network)
+from data_generator import DataGenerator
+from constants import *
 
+# Some code adapted from https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/master/src/net/hourglass.py
 
 class HourglassNet(object):
 
@@ -33,9 +36,29 @@ class HourglassNet(object):
             self.model.summary()
         
     def train(self, batch_size, model_path, epochs):
-        # TODO
-        pass
+        train_generator = DataGenerator(DEFAULT_TRAIN_ANNOT_PATH, DEFAULT_TRAIN_IMG_PATH, self.inres, self.outres, self.num_stacks, shuffle=True, batch_size=batch_size)
+        val_generator = DataGenerator(DEFAULT_VAL_ANNOT_PATH, DEFAULT_VAL_IMG_PATH, self.inres, self.outres, self.num_stacks, shuffle=True, batch_size=batch_size)
+        
+        current_time = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
+
+        csv_logger = CSVLogger(os.path.join(model_path, 'csv_tr' + current_time + '.csv'))
+
+        modelSavePath = os.path.join(model_path, current_time +  '_batchsize_' + str(batch_size), '/hg_epoch{epoch:02d}_val_loss_{val_loss:.4f}_train_loss_{loss:.4f}.hdf5')
+
+        mc_val = ModelCheckpoint(modelSavePath, monitor='val_loss')
+        mc_train = ModelCheckpoint(modelSavePath, monitor='loss')
+        tb = TensorBoard(log_dir=os.path.join(DEFAULT_LOGS_PATH, current_time + '_batchsize_' + str(batch_size)), histogram_freq=0, write_graph=True, write_images=True)
+
+        # TODO potentially add learning rate scheduler callback
+
+        callbacks = [mc_val, mc_train, tb, csv_logger]
+
+        print("Model saved to: {}".format(modelSavePath))
+
+        self.model.fit_generator(generator=train_generator, validation_data=val_generator, steps_per_epoch=len(train_generator), \
+            validation_steps=len(val_generator), epochs=epochs, callbacks=callbacks)
     
+    # TODO resume and load model
     def resume_train(self, batch_size, model_json, model_weights, init_epoch, epochs):
         # TODO
         pass

--- a/hourglass.py
+++ b/hourglass.py
@@ -11,6 +11,7 @@ from keras.optimizers import Adam, RMSprop
 from hourglass_blocks import (bottleneck_block, bottleneck_mobile,
                               create_hourglass_network)
 from data_generator import DataGenerator
+import coco_df
 from constants import *
 
 # Some code adapted from https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/master/src/net/hourglass.py
@@ -34,10 +35,19 @@ class HourglassNet(object):
         # show model summary and layer name
         if show:
             self.model.summary()
-        
+    
+    def load_and_filter_annotations(self,path_to_train_anns,path_to_val_anns):
+        df = coco_df.get_df(path_to_train_anns,path_to_val_anns)
+        # apply filters here
+        train_df = df.loc[df['source'] == 0]
+        val_df = df.loc[df['source'] == 1]
+        return train_df, val_df
+
     def train(self, batch_size, model_path, epochs):
-        train_generator = DataGenerator(DEFAULT_TRAIN_ANNOT_PATH, DEFAULT_TRAIN_IMG_PATH, self.inres, self.outres, self.num_stacks, shuffle=True, batch_size=batch_size)
-        val_generator = DataGenerator(DEFAULT_VAL_ANNOT_PATH, DEFAULT_VAL_IMG_PATH, self.inres, self.outres, self.num_stacks, shuffle=True, batch_size=batch_size)
+        train_df, val_df = self.load_and_filter_annotations(DEFAULT_TRAIN_ANNOT_PATH,DEFAULT_VAL_ANNOT_PATH)
+        #train_df, val_df = load_and_filter_annotations(COCO_TRAIN_ANNOT_PATH,COCO_VAL_ANNOT_PATH) # for google collab
+        train_generator = DataGenerator(train_df, DEFAULT_TRAIN_IMG_PATH, self.inres, self.outres, self.num_stacks, shuffle=True, batch_size=batch_size)
+        val_generator = DataGenerator(val_df, DEFAULT_VAL_IMG_PATH, self.inres, self.outres, self.num_stacks, shuffle=True, batch_size=batch_size)
         
         current_time = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
 

--- a/train.py
+++ b/train.py
@@ -1,16 +1,21 @@
 import argparse
 import os
+import time
+from datetime import datetime, timedelta
 
 import tensorflow as tf
 from keras import backend as k
 
-import constants
+from constants import *
 from hourglass import HourglassNet
 
 # TODO change to command line arguments
 num_stack = 8
 
-if __name__ == "__main__":
+def tensorflow_setup():
+    print("TensorFlow detected the following GPU(s):")
+    tf.test.gpu_device_name()
+
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
     # os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpuID)
 
@@ -19,6 +24,7 @@ if __name__ == "__main__":
 
     # Don't pre-allocate memory; allocate as-needed
     config.gpu_options.allow_growth = True
+    ## TODO may need to turn this off for the first few trials to ensure we won't run out of GPU memory mid-training
 
     # Only allow a total of half the GPU memory to be allocated
     config.gpu_options.per_process_gpu_memory_fraction = 1.0
@@ -26,7 +32,83 @@ if __name__ == "__main__":
     # Create a session with the above options specified.
     k.tensorflow_backend.set_session(tf.Session(config=config))
 
-    xnet = HourglassNet(num_classes=constants.num_classes, num_stacks=constants.num_hg_default, num_channels=256, inres=(256, 256),
+def process_args():
+    argparser = argparse.ArgumentParser(description='Training parameters')
+    argparser.add_argument('-m',
+                        '--model-save',
+                        default=DEFAULT_MODEL_PATH,
+                        help='path to save model')
+    argparser.add_argument('-e',
+                        '--epochs',
+                        default=DEFAULT_EPOCHS,
+                        type=int,
+                        help='number of epochs')
+    argparser.add_argument('-b',
+                        '--batch',
+                        type=int,
+                        default=DEFAULT_BATCH_SIZE,
+                        help='batch size')
+    argparser.add_argument('-hg',
+                        '--hourglass',
+                        type=int,
+                        default=DEFAULT_NUM_HG,
+                        help='number of hourglass blocks')
+    # Resume model training arguments
+    # TODO make a consistent way to generate and retrieve epoch checkpoint filenames
+    argparser.add_argument('-r',
+                        '--resume',
+                        default=False,
+                        type=bool,
+                        help='resume training')
+    argparser.add_argument('--resume-json',
+                        default=None,
+                        help='Model architecture for re-loading weights to resume training')
+    argparser.add_argument('--resume-weights',
+                        default=None,
+                        help='Model weights file to resume training')
+    argparser.add_argument('--resume-epoch',
+                        default=None,
+                        type=int,
+                        help='Epoch to resume training')
+
+    # Convert string arguments to appropriate type
+    args = argparser.parse_args()
+
+    return args
+
+if __name__ == "__main__":
+    args = process_args()
+
+    print("\n\nSetup start: {}\n".format(time.ctime()))
+    setup_start = time.time()
+
+    tensorflow_setup()
+
+    trainingRunTime = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
+
+    hgnet = HourglassNet(num_classes=NUM_COCO_KEYPOINTS, num_stacks=args.hourglass, num_channels=256, inres=(256, 256),
                             outres=(64, 64))
-    
-    xnet.build_model(show=True)
+
+    training_start = time.time()
+
+    if args.resume:
+        print("\n\Resume training start: {}\n".format(time.ctime()))
+
+        hgnet.resume_train(args.batch, args.resume_json, args.resume_weights, args.resume_epoch, args.epochs)
+    else:
+        hgnet.build_model(show=True)
+
+        print("\n\nTraining start: {}\n".format(time.ctime()))
+        print("Hourglass blocks: {:2d}, epochs: {:3d}, batch size: {:2d}".format(args.hourglass, args.epochs, args.batch))
+
+        hgnet.train(args.batch, args.model_save, args.epochs)
+
+    print("\n\nTraining end:   {}\n".format(time.ctime()))
+
+    training_end = time.time()
+
+    setup_time = training_start - setup_start
+    training_time = training_end - training_start
+
+    print("Total setup time: {}".format(str(timedelta(seconds=setup_time))))
+    print("Total train time: {}".format(str(timedelta(seconds=training_time))))


### PR DESCRIPTION
This PR adds support for training from scratch, with MSE loss, train and validation generators. The main additions are in `train.py` and `hourglass.py`.

`train.py` mainly adds argument parsing from command line, and supporting default fields.

`hourglass.py` adds code for `train_model`, which creates two generators: train and val, and a checkpoint saver callback.

Right now, this code is being tested locally to make sure it runs. It'll be modified for Colab support later in the day. 