### PR TITLE
Add 3 new loss functions, update training metrics to be F1, precision, and recall

### DIFF
--- a/colab_train.ipynb
+++ b/colab_train.ipynb
@@ -219,10 +219,10 @@
         "outputId": "1f977904-3e1f-4e7d-c0ac-3d8511514c14"
       },
       "source": [
-        "!python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0\n",
+        "!python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0 --loss \"euclidean_loss\"\n",
         "\n",
         "# To resume, uncomment the following and point it to the subdirectory. Ensure hourglass matches.\n",
-        "# !python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0 --resume True --resume-subdir \"2021-03-13-16h-38m_batchsize_12_hg_4\" --resume-epoch 9\n",
+        "# !python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0 --loss \"euclidean_loss\" --resume True --resume-subdir \"2021-03-13-16h-38m_batchsize_12_hg_4\" --resume-epoch 9\n",
         "\n",
         "# Note about subset: if you decide to run on a subset <1.0, there is no functionality to retrieve the same subset of data if the model is stopped then resumed. For this reason, subset should only be used for quick tests rather than reporting robust/repeatable results. "
       ],

--- a/colab_train.ipynb
+++ b/colab_train.ipynb
@@ -222,9 +222,11 @@
         "!python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0 --loss \"euclidean_loss\"\n",
         "\n",
         "# To resume, uncomment the following and point it to the subdirectory. Ensure hourglass matches.\n",
-        "# !python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0 --loss \"euclidean_loss\" --resume True --resume-subdir \"2021-03-13-16h-38m_batchsize_12_hg_4\" --resume-epoch 9\n",
+        "# !python3 train.py --epochs 100 --batch 12 --hourglass 4 --subset 1.0 --loss \"euclidean_loss\" --resume True --resume-epoch 9 --resume-subdir \"2021-03-13-16h-38m_batchsize_12_hg_4\"\n",
         "\n",
-        "# Note about subset: if you decide to run on a subset <1.0, there is no functionality to retrieve the same subset of data if the model is stopped then resumed. For this reason, subset should only be used for quick tests rather than reporting robust/repeatable results. "
+        "# Note about subset: if you decide to run on a subset <1.0, there is no functionality to retrieve the same subset of data if the model is stopped then resumed. For this reason, subset should only be used for quick tests rather than reporting robust/repeatable results. \n",
+        "\n",
+        "# Note about loss function: Ensure that the loss function matches across training sessions"
       ],
       "execution_count": null,
       "outputs": []

--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 # Colab Training
 COLAB_TRAINING = False
 
@@ -11,6 +13,14 @@ DEFAULT_OUTPUT_BASE_DIR = 'output'
 DEFAULT_RESUME_DIR_FLAG = '_resume_'
 HPE_EPOCH_PREFIX = 'hpe_epoch'
 HPE_HOURGLASS_STACKS_PREFIX = 'hpe_hourglass_stacks'
+
+# Loss Functions
+class LossFunctionOptions(Enum):
+    keras_mse = 0
+    weighted_mse = 1
+    euclidean_loss = 2
+    focal_loss = 3
+
 
 # Dataset Constants
 if COLAB_TRAINING:

--- a/constants.py
+++ b/constants.py
@@ -51,6 +51,8 @@ NUM_COCO_KEYPOINTS = 17 # Number of joints to detect
 NUM_COCO_KP_ATTRBS = 3 # (x,y,v) * 17 keypoints
 BBOX_SLACK = 1.3 # before augmentation, increase bbox size to 130%
 HEATMAP_SIGMA = 1 # As per https://towardsdatascience.com/human-pose-estimation-with-stacked-hourglass-network-and-tensorflow-c4e9f84fd3ce
+
+# Don't use, the scale is applied in the loss function.
 HEATMAP_SCALE = 1 #TODO figure out if we want to scale heatmaps, set to 1 for no effect. There are 82 times background pixels to foreground pixels in 7*7 patch of 64*64 heatmap, see same link for HEATMAP_SIGMA
 TRAIN_SHUFFLE = True # Can set to false for debug purposes
 VAL_SHUFFLE = False

--- a/hourglass.py
+++ b/hourglass.py
@@ -89,10 +89,16 @@ class HourglassNet(object):
         self.model.fit_generator(generator=train_generator, validation_data=val_generator, steps_per_epoch=len(train_generator), \
             validation_steps=len(val_generator), epochs=epochs, initial_epoch=initial_epoch, callbacks=callbacks)
 
-    def train(self, batch_size, model_save_base_dir, epochs, subset):
+    def train(self, batch_size, model_save_base_dir, epochs, subset, notes):
         current_time = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
 
         model_subdir = current_time + '_batchsize_' + str(batch_size) + '_hg_' + str(self.num_stacks)
+
+        if subset < 1.0:
+            model_subdir += '_subset_{:.2f}'.format(subset)
+        
+        if notes is not None:
+            model_subdir += notes
 
         self._start_train(batch_size=batch_size, model_base_dir=model_save_base_dir, epochs=epochs, initial_epoch=0, model_subdir=model_subdir, current_time=current_time, subset=subset)
     

--- a/hourglass.py
+++ b/hourglass.py
@@ -13,6 +13,7 @@ from hourglass_blocks import (bottleneck_block, bottleneck_mobile,
 from data_generator import DataGenerator
 import coco_df
 from constants import *
+from metrics import *
 
 # Some code adapted from https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/master/src/net/hourglass.py
 
@@ -128,7 +129,7 @@ class HourglassNet(object):
     def _compile_model(self):
         # TODO Update optimizer and/or learning rate?
         rms = RMSprop(lr=5e-4)
-        self.model.compile(optimizer=rms, loss=mean_squared_error, metrics=["accuracy"])
+        self.model.compile(optimizer=rms, loss=mean_squared_error, metrics=[f1_score, precision, recall])
 
     def _load_model(self, model_json, model_weights):
         with open(model_json) as f:

--- a/hourglass.py
+++ b/hourglass.py
@@ -130,7 +130,7 @@ class HourglassNet(object):
     def _compile_model(self):
         # TODO Update optimizer and/or learning rate?
         rms = RMSprop(lr=5e-4)
-        self.model.compile(optimizer=rms, loss=euclidean_loss, metrics=[f1, precision, recall])
+        self.model.compile(optimizer=rms, loss=euclidean_loss, metrics=[f1_m, precision_m, recall_m])
 
     def _load_model(self, model_json, model_weights):
         with open(model_json) as f:

--- a/hourglass.py
+++ b/hourglass.py
@@ -129,7 +129,7 @@ class HourglassNet(object):
     def _compile_model(self):
         # TODO Update optimizer and/or learning rate?
         rms = RMSprop(lr=5e-4)
-        self.model.compile(optimizer=rms, loss=mean_squared_error, metrics=[f1_score, precision, recall])
+        self.model.compile(optimizer=rms, loss=mean_squared_error, metrics=[mean_iou])
 
     def _load_model(self, model_json, model_weights):
         with open(model_json) as f:

--- a/hourglass.py
+++ b/hourglass.py
@@ -90,7 +90,7 @@ class HourglassNet(object):
         self.model.fit_generator(generator=train_generator, validation_data=val_generator, steps_per_epoch=len(train_generator), \
             validation_steps=len(val_generator), epochs=epochs, initial_epoch=initial_epoch, callbacks=callbacks)
 
-    def train(self, batch_size, model_save_base_dir, epochs, subset, notes):
+    def train(self, batch_size, model_save_base_dir, epochs, subset, notes=None):
         current_time = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
 
         model_subdir = current_time + '_batchsize_' + str(batch_size) + '_hg_' + str(self.num_stacks)

--- a/hourglass.py
+++ b/hourglass.py
@@ -14,6 +14,7 @@ from data_generator import DataGenerator
 import coco_df
 from constants import *
 from metrics import *
+from loss import euclidean_loss
 
 # Some code adapted from https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/master/src/net/hourglass.py
 
@@ -129,7 +130,7 @@ class HourglassNet(object):
     def _compile_model(self):
         # TODO Update optimizer and/or learning rate?
         rms = RMSprop(lr=5e-4)
-        self.model.compile(optimizer=rms, loss=mean_squared_error, metrics=[mean_iou])
+        self.model.compile(optimizer=rms, loss=euclidean_loss, metrics=[f1, precision, recall])
 
     def _load_model(self, model_json, model_weights):
         with open(model_json) as f:

--- a/hourglass.py
+++ b/hourglass.py
@@ -14,7 +14,7 @@ from data_generator import DataGenerator
 import coco_df
 from constants import *
 from metrics import *
-from loss import euclidean_loss
+from loss import *
 
 # Some code adapted from https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/master/src/net/hourglass.py
 
@@ -26,6 +26,7 @@ class HourglassNet(object):
         self.num_channels = num_channels
         self.inres = inres
         self.outres = outres
+        self.loss = None
 
     def build_model(self, mobile=False, show=False):
         if mobile:
@@ -91,7 +92,7 @@ class HourglassNet(object):
         self.model.fit_generator(generator=train_generator, validation_data=val_generator, steps_per_epoch=len(train_generator), \
             validation_steps=len(val_generator), epochs=epochs, initial_epoch=initial_epoch, callbacks=callbacks)
 
-    def train(self, batch_size, model_save_base_dir, epochs, subset, notes=None):
+    def train(self, batch_size, model_save_base_dir, epochs, subset, notes=None, loss_str=None):
         current_time = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
 
         model_subdir = current_time + '_batchsize_' + str(batch_size) + '_hg_' + str(self.num_stacks)
@@ -99,12 +100,16 @@ class HourglassNet(object):
         if subset < 1.0:
             model_subdir += '_subset_{:.2f}'.format(subset)
         
+        print('Loss function selected: {}'.format(loss_str))
+        self.loss = get_loss_from_string(loss_str)
+        model_subdir += '_loss_{}'.format(loss_str)
+
         if notes is not None:
             model_subdir += '_' + notes
 
         self._start_train(batch_size=batch_size, model_base_dir=model_save_base_dir, epochs=epochs, initial_epoch=0, model_subdir=model_subdir, current_time=current_time, subset=subset)
     
-    def resume_train(self, batch_size, model_save_base_dir, model_json, model_weights, init_epoch, epochs, resume_subdir, subset):
+    def resume_train(self, batch_size, model_save_base_dir, model_json, model_weights, init_epoch, epochs, resume_subdir, subset, loss_str):
         if resume_subdir is not None:
             print('Automatically locating model architecture .json and weights .hdf5...')
 
@@ -112,6 +117,11 @@ class HourglassNet(object):
         print('Restoring model weights: {}'.format(model_weights))
 
         self._load_model(model_json, model_weights)
+        # Load loss. NOTE: I'm pretty sure the loss function is not saved in the architecture json, so 
+        # ensure the loss option matches across training sessions
+        # TODO automatically determine correct loss option from subdir notes
+        print('Loss function selected: {}'.format(loss_str))
+        self.loss = get_loss_from_string(loss_str)
 
         current_time = datetime.today().strftime('%Y-%m-%d-%Hh-%Mm')
 
@@ -130,7 +140,12 @@ class HourglassNet(object):
     def _compile_model(self):
         # TODO Update optimizer and/or learning rate?
         rms = RMSprop(lr=5e-4)
-        self.model.compile(optimizer=rms, loss=euclidean_loss, metrics=[f1_m, precision_m, recall_m])
+
+        if self.loss is None:
+            print("No loss function provided. Using default of keras.losses.mean_squared_error")
+            self.loss = mean_squared_error
+
+        self.model.compile(optimizer=rms, loss=self.loss, metrics=[f1_m, precision_m, recall_m])
 
     def _load_model(self, model_json, model_weights):
         with open(model_json) as f:

--- a/hourglass.py
+++ b/hourglass.py
@@ -100,7 +100,7 @@ class HourglassNet(object):
             model_subdir += '_subset_{:.2f}'.format(subset)
         
         if notes is not None:
-            model_subdir += notes
+            model_subdir += '_' + notes
 
         self._start_train(batch_size=batch_size, model_base_dir=model_save_base_dir, epochs=epochs, initial_epoch=0, model_subdir=model_subdir, current_time=current_time, subset=subset)
     

--- a/hourglass_blocks.py
+++ b/hourglass_blocks.py
@@ -185,7 +185,3 @@ def create_heads(prelayerfeatures, rf1, num_classes, hgid, num_channels):
 
     head_next_stage = Add()([head, head_m, prelayerfeatures])
     return head_next_stage, head_parts
-
-
-def euclidean_loss(x, y):
-    return K.sqrt(K.sum(K.square(x - y)))

--- a/loss.py
+++ b/loss.py
@@ -1,0 +1,11 @@
+from keras import backend as K
+import tensorflow as tf
+
+# Compatible with tensorflow backend
+
+def focal_loss(gamma=2., alpha=.25):
+	def focal_loss_fixed(y_true, y_pred):
+		pt_1 = tf.where(tf.equal(y_true, 1), y_pred, tf.ones_like(y_pred))
+		pt_0 = tf.where(tf.equal(y_true, 0), y_pred, tf.zeros_like(y_pred))
+		return -K.mean(alpha * K.pow(1. - pt_1, gamma) * K.log(pt_1)) - K.mean((1 - alpha) * K.pow(pt_0, gamma) * K.log(1. - pt_0))
+	return focal_loss_fixed

--- a/loss.py
+++ b/loss.py
@@ -1,11 +1,90 @@
-from keras import backend as K
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Oct 19 08:20:58 2018
+
+@OS: Ubuntu 18.04
+@IDE: Spyder3
+@author: Aldi Faizal Dimara (Steam ID: phenomos)
+"""
+
+# Credit to https://github.com/aldi-dimara/keras-focal-loss/blob/master/focal_loss.py
+
+import keras.backend as K
 import tensorflow as tf
 
-# Compatible with tensorflow backend
+def categorical_focal_loss(gamma=2.0, alpha=0.25):
+    """
+    Implementation of Focal Loss from the paper in multiclass classification
+    Formula:
+        loss = -alpha*((1-p)^gamma)*log(p)
+    Parameters:
+        alpha -- the same as wighting factor in balanced cross entropy
+        gamma -- focusing parameter for modulating factor (1-p)
+    Default value:
+        gamma -- 2.0 as mentioned in the paper
+        alpha -- 0.25 as mentioned in the paper
+    """
+    def focal_loss(y_true, y_pred):
+        # Define epsilon so that the backpropagation will not result in NaN
+        # for 0 divisor case
+        epsilon = K.epsilon()
+        # Add the epsilon to prediction value
+        #y_pred = y_pred + epsilon
+        # Clip the prediction value
+        y_pred = K.clip(y_pred, epsilon, 1.0-epsilon)
+        # Calculate cross entropy
+        cross_entropy = -y_true*K.log(y_pred)
+        # Calculate weight that consists of  modulating factor and weighting factor
+        weight = alpha * y_true * K.pow((1-y_pred), gamma)
+        # Calculate focal loss
+        loss = weight * cross_entropy
+        # Sum the losses in mini_batch
+        loss = K.sum(loss, axis=1)
+        return loss
+    
+    return focal_loss
 
-def focal_loss(gamma=2., alpha=.25):
-	def focal_loss_fixed(y_true, y_pred):
-		pt_1 = tf.where(tf.equal(y_true, 1), y_pred, tf.ones_like(y_pred))
-		pt_0 = tf.where(tf.equal(y_true, 0), y_pred, tf.zeros_like(y_pred))
-		return -K.mean(alpha * K.pow(1. - pt_1, gamma) * K.log(pt_1)) - K.mean((1 - alpha) * K.pow(pt_0, gamma) * K.log(1. - pt_0))
-	return focal_loss_fixed
+def binary_focal_loss(gamma=2.0, alpha=0.25):
+    """
+    Implementation of Focal Loss from the paper in multiclass classification
+    Formula:
+        loss = -alpha_t*((1-p_t)^gamma)*log(p_t)
+        
+        p_t = y_pred, if y_true = 1
+        p_t = 1-y_pred, otherwise
+        
+        alpha_t = alpha, if y_true=1
+        alpha_t = 1-alpha, otherwise
+        
+        cross_entropy = -log(p_t)
+    Parameters:
+        alpha -- the same as wighting factor in balanced cross entropy
+        gamma -- focusing parameter for modulating factor (1-p)
+    Default value:
+        gamma -- 2.0 as mentioned in the paper
+        alpha -- 0.25 as mentioned in the paper
+    """
+    def focal_loss(y_true, y_pred):
+        # Define epsilon so that the backpropagation will not result in NaN
+        # for 0 divisor case
+        epsilon = K.epsilon()
+        # Add the epsilon to prediction value
+        #y_pred = y_pred + epsilon
+        # Clip the prediciton value
+        y_pred = K.clip(y_pred, epsilon, 1.0-epsilon)
+        # Calculate p_t
+        p_t = tf.where(K.equal(y_true, 1), y_pred, 1-y_pred)
+        # Calculate alpha_t
+        alpha_factor = K.ones_like(y_true)*alpha
+        alpha_t = tf.where(K.equal(y_true, 1), alpha_factor, 1-alpha_factor)
+        # Calculate cross entropy
+        cross_entropy = -K.log(p_t)
+        weight = alpha_t * K.pow((1-p_t), gamma)
+        # Calculate focal loss
+        loss = weight * cross_entropy
+        # Sum the losses in mini_batch
+        loss = K.sum(loss, axis=1)
+        return loss
+    
+    return focal_loss    

--- a/loss.py
+++ b/loss.py
@@ -88,3 +88,35 @@ def binary_focal_loss(gamma=2.0, alpha=0.25):
         return loss
     
     return focal_loss    
+
+# Compatible with tensorflow backend
+
+def focal_loss(gamma=2., alpha=.25):
+	def focal_loss_fixed(y_true, y_pred):
+		pt_1 = tf.where(tf.equal(y_true, 1), y_pred, tf.ones_like(y_pred))
+		pt_0 = tf.where(tf.equal(y_true, 0), y_pred, tf.zeros_like(y_pred))
+		return -K.mean(alpha * K.pow(1. - pt_1, gamma) * K.log(pt_1)) - K.mean((1 - alpha) * K.pow(pt_0, gamma) * K.log(1. - pt_0))
+	return focal_loss_fixed
+
+
+def weighted_MSE():
+    # Shout out to: https://towardsdatascience.com/human-pose-estimation-with-stacked-hourglass-network-and-tensorflow-c4e9f84fd3ce
+    def _weighted_mean_squared_error(y_true, y_pred):
+        loss = 0
+        # vanilla version
+        # loss += tf.math.reduce_mean(tf.math.square(y_true - y_pred))
+        # improved version
+        weights = tf.cast(y_true > 0, dtype=tf.float32) * 81 + 1
+        loss += tf.math.reduce_mean(tf.math.square(y_true - y_pred) * weights)
+
+        return loss
+    
+    def mean_squared_error(y_true, y_pred):
+        return K.mean(K.square(y_pred - y_true), axis=-1)
+    
+    def weighted_mse(y_true, y_pred):
+        weights = K.cast(K.greater(y_true, 0), dtype=K.float32)
+
+
+def euclidean_loss(x, y):
+    return K.sqrt(K.sum(K.square(x - y)))

--- a/metrics.py
+++ b/metrics.py
@@ -19,8 +19,10 @@ def f1(y_true, y_pred):
     recall = recall(y_true, y_pred)
     return 2*((precision*recall)/(precision+recall+K.epsilon()))
 
+# Broken
+# https://ai-pool.com/d/keras_iou_implementation
 def mean_iou(y_true, y_pred):
     y_pred = K.cast(K.greater(y_pred, .25), dtype='float32') # .5 is the threshold
-    inter = K.sum(K.sum(K.squeeze(y_true * y_pred, axis=3), axis=2), axis=1)
-    union = K.sum(K.sum(K.squeeze(y_true + y_pred, axis=3), axis=2), axis=1) - inter
+    inter = K.sum(K.sum(K.sum(y_true * y_pred, axis=3), axis=2), axis=1)
+    union = K.sum(K.sum(K.sum(y_true + y_pred, axis=3), axis=2), axis=1) - inter
     return K.mean((inter + K.epsilon()) / (union + K.epsilon()))

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,24 @@
+import keras
+import keras.backend as K
+import tensorflow as tf
+
+def recall(y_true, y_pred):
+    y_true = K.ones_like(y_true) 
+    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+    all_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
+    
+    recall = true_positives / (all_positives + K.epsilon())
+    return recall
+
+def precision(y_true, y_pred):
+    y_true = K.ones_like(y_true) 
+    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+    
+    predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
+    precision = true_positives / (predicted_positives + K.epsilon())
+    return precision
+
+def f1_score(y_true, y_pred):
+    prec = precision(y_true, y_pred)
+    rec = recall(y_true, y_pred)
+    return 2*((prec*rec)/(prec+rec+K.epsilon()))

--- a/metrics.py
+++ b/metrics.py
@@ -3,22 +3,24 @@ import keras.backend as K
 import tensorflow as tf
 
 def recall(y_true, y_pred):
-    y_true = K.ones_like(y_true) 
     true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
-    all_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
-    
-    recall = true_positives / (all_positives + K.epsilon())
+    possible_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
+    recall = true_positives / (possible_positives + K.epsilon())
     return recall
 
 def precision(y_true, y_pred):
-    y_true = K.ones_like(y_true) 
     true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
-    
     predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
     precision = true_positives / (predicted_positives + K.epsilon())
     return precision
 
-def f1_score(y_true, y_pred):
-    prec = precision(y_true, y_pred)
-    rec = recall(y_true, y_pred)
-    return 2*((prec*rec)/(prec+rec+K.epsilon()))
+def f1(y_true, y_pred):
+    precision = precision(y_true, y_pred)
+    recall = recall(y_true, y_pred)
+    return 2*((precision*recall)/(precision+recall+K.epsilon()))
+
+def mean_iou(y_true, y_pred):
+    y_pred = K.cast(K.greater(y_pred, .25), dtype='float32') # .5 is the threshold
+    inter = K.sum(K.sum(K.squeeze(y_true * y_pred, axis=3), axis=2), axis=1)
+    union = K.sum(K.sum(K.squeeze(y_true + y_pred, axis=3), axis=2), axis=1) - inter
+    return K.mean((inter + K.epsilon()) / (union + K.epsilon()))

--- a/metrics.py
+++ b/metrics.py
@@ -2,21 +2,21 @@ import keras
 import keras.backend as K
 import tensorflow as tf
 
-def recall(y_true, y_pred):
+def recall_m(y_true, y_pred):
     true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
     possible_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
     recall = true_positives / (possible_positives + K.epsilon())
     return recall
 
-def precision(y_true, y_pred):
+def precision_m(y_true, y_pred):
     true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
     predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
     precision = true_positives / (predicted_positives + K.epsilon())
     return precision
 
-def f1(y_true, y_pred):
-    precision = precision(y_true, y_pred)
-    recall = recall(y_true, y_pred)
+def f1_m(y_true, y_pred):
+    precision = precision_m(y_true, y_pred)
+    recall = recall_m(y_true, y_pred)
     return 2*((precision*recall)/(precision+recall+K.epsilon()))
 
 # Broken

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ opencv-python==4.4.0.42
 matplotlib
 numpy
 requests
+pycocotools @ git+https://github.com/philferriere/cocoapi.git@2929bd2ef6b451054755dfd7ceb09278f935f7ad#subdirectory=PythonAPI

--- a/scripts/coco_dl.sh
+++ b/scripts/coco_dl.sh
@@ -1,4 +1,4 @@
-# Credit to https://gist.github.com/mkocabas/a6177fc00315403d31572e17700d7fd9
+# Adapted from https://gist.github.com/mkocabas/a6177fc00315403d31572e17700d7fd9
 
 dataset_root_path="./data"
 

--- a/train.py
+++ b/train.py
@@ -59,6 +59,10 @@ def process_args():
                         type=float,
                         default=1.0,
                         help='fraction of train set to train on, default 1.0')
+    argparser.add_argument('-l',
+                        '--loss',
+                        default=LossFunctionOptions.keras_mse.name,
+                        help='Loss function for model training')
     # Resume model training arguments
     # TODO make a consistent way to generate and retrieve epoch checkpoint filenames
     argparser.add_argument('-r',
@@ -124,14 +128,14 @@ if __name__ == "__main__":
     if args.resume:
         print("\n\nResume training start: {}\n".format(time.ctime()))
 
-        hgnet.resume_train(args.batch, args.model_save, args.resume_json, args.resume_weights, args.resume_epoch, args.epochs, args.resume_subdir, args.subset)
+        hgnet.resume_train(args.batch, args.model_save, args.resume_json, args.resume_weights, args.resume_epoch, args.epochs, args.resume_subdir, args.subset, loss_str=args.loss)
     else:
         hgnet.build_model(show=True)
 
         print("\n\nTraining start: {}\n".format(time.ctime()))
         print("Hourglass blocks: {:2d}, epochs: {:3d}, batch size: {:2d}, subset: {:.2f}".format(args.hourglass, args.epochs, args.batch, args.subset))
 
-        hgnet.train(args.batch, args.model_save, args.epochs, args.subset, args.notes)
+        hgnet.train(args.batch, args.model_save, args.epochs, args.subset, args.notes, loss_str=args.loss)
 
     print("\n\nTraining end:   {}\n".format(time.ctime()))
 

--- a/train.py
+++ b/train.py
@@ -86,8 +86,15 @@ def process_args():
     # Validate arguments
     assert (args.subset > 0 and args.subset <= 1.0), "Subset must be fraction between 0 and 1.0"
 
-    if args.resume and args.resume_subdir is not None:
-        find_resume_json_weights(args)
+    if args.resume:
+        assert args.resume_epoch > 0, "Resume epoch number must be greater than 0."
+
+        # Automatically locate architecture json and model weights
+        if args.resume_subdir is not None:
+            find_resume_json_weights(args)
+        
+        assert args.resume_json is not None and args.resume_weights is not None, \
+            "Resume model training enabled, but no parameters received for: --resume-subdir, or both --resume-json and --resume-weights"
 
     return args
 

--- a/train.py
+++ b/train.py
@@ -79,6 +79,10 @@ def process_args():
     argparser.add_argument('--resume-subdir',
                         default=None,
                         help='Subdirectory containing architecture json and weights')
+    # Misc
+    argparser.add_argument('--notes',
+                        default=None,
+                        help='Any notes to save with the model path. Prefer no spaces')
 
     # Convert string arguments to appropriate type
     args = argparser.parse_args()
@@ -95,6 +99,10 @@ def process_args():
         
         assert args.resume_json is not None and args.resume_weights is not None, \
             "Resume model training enabled, but no parameters received for: --resume-subdir, or both --resume-json and --resume-weights"
+
+    if args.notes is not None:
+        # Clean notes so it can be used in directory name
+        args.notes = slugify(args.notes)
 
     return args
 
@@ -123,7 +131,7 @@ if __name__ == "__main__":
         print("\n\nTraining start: {}\n".format(time.ctime()))
         print("Hourglass blocks: {:2d}, epochs: {:3d}, batch size: {:2d}, subset: {:.2f}".format(args.hourglass, args.epochs, args.batch, args.subset))
 
-        hgnet.train(args.batch, args.model_save, args.epochs, args.subset)
+        hgnet.train(args.batch, args.model_save, args.epochs, args.subset, args.notes)
 
     print("\n\nTraining end:   {}\n".format(time.ctime()))
 

--- a/util.py
+++ b/util.py
@@ -10,8 +10,8 @@ def find_resume_json_weights(args):
     model_jsons         = [f for f in files if (".json" in f and HPE_HOURGLASS_STACKS_PREFIX in f)]
     model_saved_weights = [f for f in files if (".hdf5" in f and "{prefix}{epoch:02d}".format(prefix=HPE_EPOCH_PREFIX, epoch=args.resume_epoch) in f)]
     
-    assert len(model_jsons) > 0
-    assert len(model_saved_weights) > 0
+    assert len(model_jsons) > 0, "Subdirectory does not contain any model architecture json files"
+    assert len(model_saved_weights) > 0, "Subdirectory does not contain any saved model weights"
 
     args.resume_json = os.path.join(enclosing_dir, model_jsons[0])
     args.resume_weights = os.path.join(enclosing_dir, model_saved_weights[0])

--- a/util.py
+++ b/util.py
@@ -1,6 +1,9 @@
 import os
+import re
+import unicodedata
 
 from constants import *
+
 
 def find_resume_json_weights(args):
     enclosing_dir = os.path.join(args.model_save, args.resume_subdir)
@@ -21,3 +24,19 @@ def find_resume_json_weights(args):
 
     assert os.path.exists(args.resume_json)
     assert os.path.exists(args.resume_weights)
+
+def slugify(value, allow_unicode=False):
+    """
+    Taken from https://github.com/django/django/blob/master/django/utils/text.py
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize('NFKC', value)
+    else:
+        value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = re.sub(r'[^\w\s-]', '', value.lower())
+    return re.sub(r'[-\s]+', '-', value).strip('-_')


### PR DESCRIPTION
We've noticed that training has resulted in the model (likely) finding a local minima of guessing all 0's or a value equal to the mean value of a heat map. This is because the `mean squared error` metric doesn't work well for a large imbalance of 0's and non-0's, which is what our heat map consists of.

## New
- 4 different loss functions: 
    - `keras_mse`: the unmodified mean squared error from keras.losses
    - `weighted_mse`: weighs the 1's as 82 times more intense than the 0's. This parameter may require adjustment.
    - `euclidean_loss`: similar to a mean squared error, but does not involve averaging it. 
    - `focal_loss`: significantly increases the weight of incorrect predictions for the less frequent class (the keypoint location)
- updated metrics to something that is a bit more interpretable, but still not great
    - accuracy just wasn't cutting it for us. This is because it's a classification metric, and is looking at exact matches. I've changed it to `f1`, which is similar to intersection-over-union, which is a _bit_ more useful

The losses are adjustable with command line arguments with the `--loss` flag.

## Quality of Life
- I've added a "notes" flag that allows us to add specific notes to the model session directory name. This is useful if we want to keep track of what we're testing

## TODO
- If someone could test these losses and metrics that would be amazing. See https://stackoverflow.com/questions/50862101/how-to-test-a-custom-loss-function-in-keras