### PR TITLE
Corey/data split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # VS Code Settings
 .vscode/*
+
+#Pickles and pickle directories
+Pickles/*

--- a/constants.py
+++ b/constants.py
@@ -39,11 +39,13 @@ if COLAB_TRAINING:
     DEFAULT_VAL_ANNOT_PATH = '/content/datasets/annotations/person_keypoints_val2017.json'
     DEFAULT_TRAIN_IMG_PATH = '/content/datasets/coco'
     DEFAULT_VAL_IMG_PATH = '/content/datasets/coco'
+    DEFAULT_PICKLE_PATH = '/content/gdrive/MyDrive/Colab Data/COCO-Human-Pose/Pickles/'
 else:
     DEFAULT_TRAIN_ANNOT_PATH = 'data/annotations/person_keypoints_train2017.json'
     DEFAULT_VAL_ANNOT_PATH = 'data/annotations/person_keypoints_val2017.json'
     DEFAULT_TRAIN_IMG_PATH = 'data/coco'
     DEFAULT_VAL_IMG_PATH = 'data/coco'
+    DEFAULT_PICKLE_PATH = './Pickles/'
 
 COCO_KEYPOINT_LABEL_ARR = ["nose","left_eye","right_eye","left_ear","right_ear","left_shoulder","right_shoulder","left_elbow","right_elbow","left_wrist","right_wrist","left_hip","right_hip","left_knee","right_knee","left_ankle","right_ankle"]
 

--- a/df_pickler.py
+++ b/df_pickler.py
@@ -1,0 +1,78 @@
+# Pickles and unpickles data frames for maintaining consistant dataframes.
+
+import numpy as np
+import pandas as pd
+import os
+import skimage.io as io
+import coco_df
+from constants import *
+from pycocotools.coco import COCO
+from sklearn.model_selection import train_test_split
+
+
+
+
+def check_pickle_folder(pickle_folder, pickle_path = DEFAULT_PICKLE_PATH) -> bool:
+    # Checks if the folder exists
+    return os.path.isdir(os.path.join(pickle_path, pickle_folder))
+    
+
+def create_folder(pickle_folder, pickle_path = DEFAULT_PICKLE_PATH):
+    # Creates a folder
+    pf = os.path.join(pickle_path, pickle_folder)
+    if check_pickle_folder(pickle_folder, pickle_path):
+        print(f'Folder {pickle_folder} exists')
+        return pf
+    print(pf)
+    os.mkdir(pf)
+    return pf
+
+def make_pickle(is_crowd: bool, drop_empty: bool, scale: float,TV_split: float, drop_small_bbox=BBOX_MIN_SIZE):
+    if scale <= 0.0 or scale > 1.0:
+        raise ValueError
+    if TV_split <= 0.0 or scale > 1.0:
+        raise ValueError
+    pickle_name = pickle_namer(is_crowd, drop_empty, scale, TV_split, drop_small_bbox)
+    pickle_folder = create_folder(pickle_name)
+    df = coco_df.get_df(DEFAULT_TRAIN_ANNOT_PATH, DEFAULT_VAL_ANNOT_PATH)
+    if is_crowd:
+        df = df.loc[df['is_crowd'] == 0]
+    if drop_empty:
+        df = df.loc[df['num_keypoints'] != 0]
+    df = df.loc[df['bbox_area'] > drop_small_bbox]
+    df_TrV = df.loc[df['source'] == 0] #Data from the training set for splitting into train/val
+    df_Tst = df.loc[df['source'] == 1] #Data from the val set for testing
+    t_size = scale * TV_split
+    v_size = scale * (1-TV_split)
+    df_Tr, df_V = train_test_split(df_TrV, train_size=t_size, test_size=v_size) # We can stratify here if wanted as well
+    df_Tr.to_pickle(os.path.join(pickle_folder, f'Train_{pickle_name}.pkl'))
+    df_V.to_pickle(os.path.join(pickle_folder, f'Val_{pickle_name}.pkl'))
+    df_Tst.to_pickle(os.path.join(pickle_folder, f'Test_{pickle_name}.pkl'))
+    return
+    
+
+def get_pickle(pickle_name):
+    pickle_folder = os.path.join(DEFAULT_PICKLE_PATH, pickle_name)
+    df_Tr = pd.read_pickle(os.path.join(pickle_folder, f'Train_{pickle_name}.pkl'))
+    df_V = pd.read_pickle(os.path.join(pickle_folder, f'Val_{pickle_name}.pkl'))
+    df_Tst = pd.read_pickle(os.path.join(pickle_folder, f'Test_{pickle_name}.pkl'))
+    return df_Tr.reset_index(), df_V.reset_index(), df_Tst.reset_index()
+
+def pickle_namer(is_crowd, drop_empty, scale, TV_split, drop_small_bbox):
+    filename = f''
+    filename += f'C-{is_crowd}_'
+    filename += f'DE-{drop_empty}_'
+    filename += f'S-{int(scale*100)}_'
+    filename += f'TVs-{int(TV_split*100)}_'
+    filename += f'DSBB-{drop_small_bbox}'
+    return filename
+
+def parse_pickle_name(filename):
+    data =  [val for val in filename.split('.')[0].split('_')]
+    print(f'Settings for pickle ({filename}):')
+    print(f'  Crowd enabled              : {data[0].split("-")[1]}')
+    print(f'  Drop Empty                 : {data[1].split("-")[1]}')
+    print(f'  Dataframe scaling          : {data[2].split("-")[1]/100}')
+    print(f'  Test/validation splot      : {data[3].split("-")[1]/100}')
+    print(f'  Bounding box lower limit   : {data[4].split("-")[1]}')
+    return

--- a/pickle_maker.ipynb
+++ b/pickle_maker.ipynb
@@ -66,7 +66,8 @@
             },
             "source": [
                 "# Download dataset to pre-specified folder on local VM instance\n",
-                "%cd /content/\n",
+                "# Change dir to project dir\n",
+                "%cd \"/content/gdrive/MyDrive/Colab Data/COCO-Human-Pose\"\n",
                 "\n",
                 "import time\n",
                 "from datetime import datetime, timedelta\n",
@@ -102,16 +103,15 @@
                 "outputId": "6eabcec6-4aeb-4a95-9451-c9dc7d3d0314"
             },
             "source": [
-                "# Change dir to project dir\n",
-                "%cd \"/content/gdrive/MyDrive/Colab Data/COCO-Human-Pose\"\n",
-                "\n",
                 "# Toggle COLAB_TRAINING variable in constants file\n",
                 "# https://askubuntu.com/questions/20414/find-and-replace-text-within-a-file-using-commands\n",
                 "!sed -i.bak 's/COLAB_TRAINING = False/COLAB_TRAINING = True/g' constants.py \n",
                 "\n",
                 "# Remove backup file\n",
                 "!rm constants.py.bak\n",
-                "\n"
+                "\n",
+                "# Upgrade required imgaug package because of a bug on 0.2.9\n",
+                "!pip install --upgrade imgaug==0.4.0"
             ],
             "execution_count": null,
             "outputs": []

--- a/pickle_maker.ipynb
+++ b/pickle_maker.ipynb
@@ -1,0 +1,159 @@
+{
+    "nbformat": 4,
+    "nbformat_minor": 0,
+    "metadata": {
+        "colab": {
+            "name": "pickle_maker.ipynb",
+            "provenance": [],
+            "collapsed_sections": [],
+            "toc_visible": true,
+            "machine_shape": "hm"
+        },
+        "kernelspec": {
+            "display_name": "Python 3",
+            "name": "python3"
+        },
+        "accelerator": "GPU"
+    },
+    "cells": [
+        {
+            "cell_type": "code",
+            "metadata": {
+                "id": "RUQcY5kdrWiO",
+                "colab": {
+                    "base_uri": "https://localhost:8080/"
+                },
+                "executionInfo": {
+                    "status": "ok",
+                    "timestamp": 1616484284681,
+                    "user_tz": 420,
+                    "elapsed": 22800,
+                    "user": {
+                        "displayName": "Corey Koelewyn",
+                        "photoUrl": "",
+                        "userId": "10684872829383928279"
+                    }
+                },
+                "outputId": "e20ae0c6-0626-476e-8d0f-1127d14d7453"
+            },
+            "source": [
+                "# Mount Google Drive\n",
+                "from google.colab import drive\n",
+                "drive.mount('/content/gdrive')"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {
+                "id": "yWlpeOl829ji",
+                "colab": {
+                    "base_uri": "https://localhost:8080/"
+                },
+                "executionInfo": {
+                    "status": "ok",
+                    "timestamp": 1616527132443,
+                    "user_tz": 420,
+                    "elapsed": 68310,
+                    "user": {
+                        "displayName": "Corey Koelewyn",
+                        "photoUrl": "",
+                        "userId": "10684872829383928279"
+                    }
+                },
+                "outputId": "6385e676-3dd0-4ce2-9804-a49827901f48"
+            },
+            "source": [
+                "# Download dataset to pre-specified folder on local VM instance\n",
+                "%cd /content/\n",
+                "\n",
+                "import time\n",
+                "from datetime import datetime, timedelta\n",
+                "\n",
+                "start = time.time()\n",
+                "\n",
+                "!bash \"/content/gdrive/MyDrive/Colab Data/COCO-Human-Pose/scripts/coco_dl.sh\" ./datasets no_image\n",
+                "\n",
+                "download_time = time.time() - start\n",
+                "print(\"Total download time: {}\".format(str(timedelta(seconds=download_time))))"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {
+                "id": "UeLJoy2iz5sE",
+                "colab": {
+                    "base_uri": "https://localhost:8080/"
+                },
+                "executionInfo": {
+                    "status": "ok",
+                    "timestamp": 1616530222107,
+                    "user_tz": 420,
+                    "elapsed": 691,
+                    "user": {
+                        "displayName": "Corey Koelewyn",
+                        "photoUrl": "",
+                        "userId": "10684872829383928279"
+                    }
+                },
+                "outputId": "6eabcec6-4aeb-4a95-9451-c9dc7d3d0314"
+            },
+            "source": [
+                "# Change dir to project dir\n",
+                "%cd \"/content/gdrive/MyDrive/Colab Data/COCO-Human-Pose\"\n",
+                "\n",
+                "# Toggle COLAB_TRAINING variable in constants file\n",
+                "# https://askubuntu.com/questions/20414/find-and-replace-text-within-a-file-using-commands\n",
+                "!sed -i.bak 's/COLAB_TRAINING = False/COLAB_TRAINING = True/g' constants.py \n",
+                "\n",
+                "# Remove backup file\n",
+                "!rm constants.py.bak\n",
+                "\n"
+            ],
+            "execution_count": null,
+            "outputs": []
+        },
+        {
+            "cell_type": "code",
+            "metadata": {
+                "colab": {
+                    "base_uri": "https://localhost:8080/"
+                },
+                "id": "au2ZugKpMRHL",
+                "executionInfo": {
+                    "status": "ok",
+                    "timestamp": 1616530333453,
+                    "user_tz": 420,
+                    "elapsed": 17145,
+                    "user": {
+                        "displayName": "Corey Koelewyn",
+                        "photoUrl": "",
+                        "userId": "10684872829383928279"
+                    }
+                },
+                "outputId": "c7d8a9f3-0cc7-4d4f-f567-52e813b809ba"
+            },
+            "source": [
+                "from df_pickler import *\n",
+                "import os\n",
+                "import constants\n",
+                "if not os.path.exists(DEFAULT_PICKLE_PATH):\n",
+                "  os.makedirs(DEFAULT_PICKLE_PATH)\n",
+                "\n",
+                "\n",
+                "filter_crowds = True\n",
+                "remove_empty = True\n",
+                "scale_factor = .8\n",
+                "train_val_split = .8\n",
+                "# bound_box_lower_cutoff = 900 # uses default from constants.py if no value given\n",
+                "\n",
+                "make_pickle(filter_crowds, remove_empty, scale_factor, train_val_split)\n"
+            ],
+            "execution_count": null,
+            "outputs": []
+        }
+    ]
+}

--- a/scripts/coco_dl.sh
+++ b/scripts/coco_dl.sh
@@ -2,7 +2,7 @@
 
 dataset_root_path="./data"
 
-if [[ $# -eq 1 ]] ; then
+if [[ $# >= 1 ]] ; then
     dataset_root_path=$1
 fi
 
@@ -37,39 +37,45 @@ fi
 #     Download COCO2017 Images        #
 #######################################
 
-if [ ! -d "coco" ]; then
-    mkdir coco
+# if the second argument is "no_image" then we want the images.
+if [[ $2 != "no_image" ]]; then 
+    if [ ! -d "coco" ]; then
+        mkdir coco
+    fi
+
+    cd coco
+
+    for imgs_zip in "${arrCocoImg[@]}"
+    do
+        if [ ! -f $imgs_zip.zip -a ! -d $imgs_zip ]; then
+            echo "$imgs_zip.zip and $imgs_zip/ not found!"
+            echo "Downloading from... http://images.cocodataset.org/zips/$imgs_zip.zip"
+            curl -OL http://images.cocodataset.org/zips/$imgs_zip.zip
+        fi
+        
+        if [ -f $imgs_zip.zip ]; then
+            if [ "$enable_unzip" = true ] ; then
+                echo "Unzipping: $imgs_zip.zip"
+                unzip -q $imgs_zip.zip
+            fi
+
+            if [ "$remove_zip" = true ] ; then
+                echo "Deleting file: $imgs_zip.zip"
+                rm $imgs_zip.zip
+            fi
+        else
+            echo "$imgs_zip.zip not found. Ignoring zip-related instructions..."
+        fi
+    done
+
+# Moved this as its only needed if Image dataset is downloaded
+cd ../
+
 fi
-
-cd coco
-
-for imgs_zip in "${arrCocoImg[@]}"
-do
-    if [ ! -f $imgs_zip.zip -a ! -d $imgs_zip ]; then
-        echo "$imgs_zip.zip and $imgs_zip/ not found!"
-        echo "Downloading from... http://images.cocodataset.org/zips/$imgs_zip.zip"
-        curl -OL http://images.cocodataset.org/zips/$imgs_zip.zip
-    fi
-    
-    if [ -f $imgs_zip.zip ]; then
-        if [ "$enable_unzip" = true ] ; then
-            echo "Unzipping: $imgs_zip.zip"
-            unzip -q $imgs_zip.zip
-        fi
-
-        if [ "$remove_zip" = true ] ; then
-            echo "Deleting file: $imgs_zip.zip"
-            rm $imgs_zip.zip
-        fi
-    else
-        echo "$imgs_zip.zip not found. Ignoring zip-related instructions..."
-    fi
-done
 
 #######################################
 #    Download COCO2017 Annotations    #
 #######################################
-cd ../
 
 for annos_zip in "${arrCocoAnno[@]}"
 do

--- a/train.py
+++ b/train.py
@@ -2,10 +2,12 @@ import argparse
 import os
 import time
 from datetime import datetime, timedelta
+from pandas.io import pickle
 
 import tensorflow as tf
 from keras import backend as k
 
+from df_pickler import check_pickle_folder
 from constants import *
 from hourglass import HourglassNet
 from util import *
@@ -87,6 +89,9 @@ def process_args():
     argparser.add_argument('--resume-subdir',
                         default=None,
                         help='Subdirectory containing architecture json and weights')
+    argparser.add_argument('--pickle',
+                        default=None,
+                        help='Name of folder with pickled dataframes')
     # Misc
     argparser.add_argument('--notes',
                         default=None,
@@ -107,6 +112,13 @@ def process_args():
         
         assert args.resume_json is not None and args.resume_weights is not None, \
             "Resume model training enabled, but no parameters received for: --resume-subdir, or both --resume-json and --resume-weights"
+
+    if args.pickle is not None:
+        #Check to see if pickle exists, changes to None if it doesn't.
+        if not check_pickle_folder(args.pickle):
+            print(f'{args.pickle} does not exist, changing to None')
+            args.pickle = None
+
 
     if args.notes is not None:
         # Clean notes so it can be used in directory name
@@ -133,7 +145,7 @@ if __name__ == "__main__":
         print("\n\nResume training start: {}\n".format(time.ctime()))
 
         hgnet.resume_train(args.batch, args.model_save, args.resume_json, args.resume_weights, \
-            args.resume_epoch, args.epochs, args.resume_subdir, args.subset, loss_str=args.loss, image_aug_str=args.augment)
+            args.resume_epoch, args.epochs, args.resume_subdir, args.subset, loss_str=args.loss, image_aug_str=args.augment, pickle_name=args.pickle)
     else:
         hgnet.build_model(show=True)
 
@@ -141,7 +153,7 @@ if __name__ == "__main__":
         print("Hourglass blocks: {:2d}, epochs: {:3d}, batch size: {:2d}, subset: {:.2f}".format(\
             args.hourglass, args.epochs, args.batch, args.subset))
 
-        hgnet.train(args.batch, args.model_save, args.epochs, args.subset, args.notes, loss_str=args.loss, image_aug_str=args.augment)
+        hgnet.train(args.batch, args.model_save, args.epochs, args.subset, args.notes, loss_str=args.loss, image_aug_str=args.augment, pickle_name=args.pickle)
 
     print("\n\nTraining end:   {}\n".format(time.ctime()))
 


### PR DESCRIPTION
This PR covers task **Create a new train/val from train (possibly need stratification)**. 

Use the `pickle_maker.ipynb` notebook for creating pickles in your GDrive
Use the `--pickle` argument with `train.py` in `colab_train.ipynb` to specify which pickle you want to train on.

Features
 * df_pickler module with functions for creating pickle files from dataframes and reading data frames from pickle files
   * Creates training, validation, and testing datasets (training and validation come from COCO's training, testing comes from COCO's testing)
 * Notebook file `pickle_maker.ipynb` for creating pickle files in your google drive
 * new arg `--pickle` specifies which pickle you want to consume
    * If pickle flag not used train.py uses `hourglass.load_and_filter_annotations()` to generate training and validation dataframes
    * If the pickle doesn't exist, an error is output and train.py uses `hourglass.load_and_filter_annotations()` to generate training and validation dataframes
  * new script `anno_dl.sh` for downloading only annotation zips.

Potential issues
  * naming scheme for model folders won't reflect which pickle this came from
  * stratification is not currently implemented, could result in training and validation sets having unequal representation of different parameters.
