### PR TITLE
Add Heatmap to Keypoint Functionality

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -75,3 +75,6 @@ VAL_SHUFFLE = False
 
 # Data filtering constants
 BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
+
+# Output filtering constants
+HM_TO_KP_THRESHOLD = 0.05

--- a/constants.py
+++ b/constants.py
@@ -67,6 +67,7 @@ BBOX_SLACK = 1.3 # before augmentation, increase bbox size to 130%
 
 # NOTE: The effective sigma is downscaled by a factor of 4 (from (256,256) to (64,64)) on each side, so ensure the sigma is appropriately sized
 HEATMAP_SIGMA = 4 # As per https://towardsdatascience.com/human-pose-estimation-with-stacked-hourglass-network-and-tensorflow-c4e9f84fd3ce
+REVERSE_HEATMAP_SIGMA = 1 # Use reverse sigma when heatmap is reversed by a factor of 4 from (64,64) to (256,256)
 
 # NOTE: Don't use, the scale is applied in the loss function.
 HEATMAP_SCALE = 1 #TODO figure out if we want to scale heatmaps, set to 1 for no effect. There are 82 times background pixels to foreground pixels in 7*7 patch of 64*64 heatmap, see same link for HEATMAP_SIGMA
@@ -77,4 +78,4 @@ VAL_SHUFFLE = False
 BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 
 # Output filtering constants
-HM_TO_KP_THRESHOLD = 0.05
+HM_TO_KP_THRESHOLD = 0.2

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,4 +1,11 @@
+<<<<<<< HEAD
 import cv2
+=======
+from HeatMap import HeatMap # https://github.com/LinShanify/HeatMap
+from constants import *
+from scipy.ndimage import gaussian_filter, maximum_filter
+
+>>>>>>> Added heatmap to keypoint functionality
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
@@ -135,3 +142,38 @@ def load_and_preprocess_img(img_path, num_hg_blocks, x=None, y=None, w=None, h=N
     y_batch = [np.zeros((1, *(OUTPUT_DIM), NUM_COCO_KEYPOINTS)) for _ in range(num_hg_blocks)]
 
     return X_batch, y_batch
+
+    # Resources for heatmaps to keypoints
+    # https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/eddf0ae15715a88d7859847cfff5f5092b260ae1/src/eval/heatmap_process.py#L5
+    # https://github.com/david8862/tf-keras-stacked-hourglass-keypoint-detection/blob/56707252501c73b2bf2aac8fff3e22760fd47dca/hourglass/postprocess.py#L17
+   
+    ### Returns np array of predicted keypoints from one image's heatmaps
+    def heatmaps_to_keypoints(self, heatmaps, threshold=1e-2):
+        keypoints = list()
+        for i in range(NUM_COCO_KEYPOINTS):
+            hmap = heatmaps[:,:,i]
+            # Do a heatmap blur with gaussian_filter
+            hmap = gaussian_filter(hmap, HEATMAP_SIGMA)
+
+            # Resize heatmap from Output DIM to Input DIM
+            resized_hmap = cv2.resize(hmap, INPUT_DIM, interpolation = cv2.INTER_AREA)
+
+            # Get peak point (brightest area) in heatmap with 3x3 max filter
+            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=1e-2)
+
+            # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
+            # and get its coordinates and confidence
+            y, x = np.where(peaks == peaks.max())
+            if len(x) > 0 and len(y) > 0:
+                keypoints.append((int(x[0]), int(y[0]), peaks[y[0], x[0]]))
+            else:
+                keypoints.append((0, 0, 0))
+        # Turn keypoints into np array
+        keypoints = np.array(keypoints)
+        return keypoints
+
+    def _non_max_supression(self, plain, windowSize=3, threshold=1e-2):
+        # Clear values less than threshold
+        under_thresh_indices = plain < threshold
+        plain[under_thresh_indices] = 0
+        return plain * (plain == maximum_filter(plain, footprint=np.ones((windowSize, windowSize))))

--- a/evaluation.py
+++ b/evaluation.py
@@ -99,7 +99,42 @@ class Evaluation():
         img_v_resize = self._vstack_images(heatmap_imgs) 
         
         cv2.imwrite(filename, img_v_resize) 
-    
+
+    # Resources for heatmaps to keypoints
+    # https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/eddf0ae15715a88d7859847cfff5f5092b260ae1/src/eval/heatmap_process.py#L5
+    # https://github.com/david8862/tf-keras-stacked-hourglass-keypoint-detection/blob/56707252501c73b2bf2aac8fff3e22760fd47dca/hourglass/postprocess.py#L17
+   
+    ### Returns np array of predicted keypoints from one image's heatmaps
+    def heatmaps_to_keypoints(self, heatmaps, threshold=1e-2):
+        keypoints = list()
+        for i in range(NUM_COCO_KEYPOINTS):
+            hmap = heatmaps[:,:,i]
+            
+            # Do a heatmap blur with gaussian_filter
+            hmap = gaussian_filter(hmap, HEATMAP_SIGMA)
+             # Resize heatmap from Output DIM to Input DIM
+            resized_hmap = cv2.resize(hmap, INPUT_DIM, interpolation = cv2.INTER_AREA)
+
+            # Get peak point (brightest area) in heatmap with 3x3 max filter
+            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=1e-2)
+
+            # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
+            # and get its coordinates and confidence
+            y, x = np.where(peaks == peaks.max())
+            if len(x) > 0 and len(y) > 0:
+                keypoints.append((int(x[0]), int(y[0]), peaks[y[0], x[0]]))
+            else:
+                keypoints.append((0, 0, 0))
+        # Turn keypoints into np array
+        keypoints = np.array(keypoints)
+        print(keypoints)
+        return keypoints
+
+    def _non_max_supression(self, plain, windowSize=3, threshold=1e-2):
+        # Clear values less than threshold
+        under_thresh_indices = plain < threshold
+        plain[under_thresh_indices] = 0
+        return plain * (plain == maximum_filter(plain, footprint=np.ones((windowSize, windowSize))))
 
 """
 Runs the model for any general file. This aims to extend the DataGenerator output format for arbitrary images
@@ -137,38 +172,3 @@ def load_and_preprocess_img(img_path, num_hg_blocks, x=None, y=None, w=None, h=N
     y_batch = [np.zeros((1, *(OUTPUT_DIM), NUM_COCO_KEYPOINTS)) for _ in range(num_hg_blocks)]
 
     return X_batch, y_batch
-
-    # Resources for heatmaps to keypoints
-    # https://github.com/yuanyuanli85/Stacked_Hourglass_Network_Keras/blob/eddf0ae15715a88d7859847cfff5f5092b260ae1/src/eval/heatmap_process.py#L5
-    # https://github.com/david8862/tf-keras-stacked-hourglass-keypoint-detection/blob/56707252501c73b2bf2aac8fff3e22760fd47dca/hourglass/postprocess.py#L17
-   
-    ### Returns np array of predicted keypoints from one image's heatmaps
-    def heatmaps_to_keypoints(self, heatmaps, threshold=1e-2):
-        keypoints = list()
-        for i in range(NUM_COCO_KEYPOINTS):
-            hmap = heatmaps[:,:,i]
-            # Do a heatmap blur with gaussian_filter
-            hmap = gaussian_filter(hmap, HEATMAP_SIGMA)
-
-            # Resize heatmap from Output DIM to Input DIM
-            resized_hmap = cv2.resize(hmap, INPUT_DIM, interpolation = cv2.INTER_AREA)
-
-            # Get peak point (brightest area) in heatmap with 3x3 max filter
-            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=1e-2)
-
-            # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
-            # and get its coordinates and confidence
-            y, x = np.where(peaks == peaks.max())
-            if len(x) > 0 and len(y) > 0:
-                keypoints.append((int(x[0]), int(y[0]), peaks[y[0], x[0]]))
-            else:
-                keypoints.append((0, 0, 0))
-        # Turn keypoints into np array
-        keypoints = np.array(keypoints)
-        return keypoints
-
-    def _non_max_supression(self, plain, windowSize=3, threshold=1e-2):
-        # Clear values less than threshold
-        under_thresh_indices = plain < threshold
-        plain[under_thresh_indices] = 0
-        return plain * (plain == maximum_filter(plain, footprint=np.ones((windowSize, windowSize))))

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,6 +1,5 @@
 import cv2
 from scipy.ndimage import gaussian_filter, maximum_filter
-
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
@@ -115,7 +114,7 @@ class Evaluation():
             resized_hmap = gaussian_filter(resized_hmap, HEATMAP_SIGMA)
 
             # Get peak point (brightest area) in heatmap with 3x3 max filter
-            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=HM_TO_KP_THRESHOLD)
+            peaks = self._non_max_supression(resized_hmap, threshold, windowSize=3)
 
             # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
             # and get its coordinates and confidence
@@ -128,7 +127,7 @@ class Evaluation():
         keypoints = np.array(keypoints)
         return keypoints
 
-    def _non_max_supression(self, plain, windowSize=3, threshold=HM_TO_KP_THRESHOLD):
+    def _non_max_supression(self, plain, threshold, windowSize=3):
         # Clear values less than threshold
         under_thresh_indices = plain < threshold
         plain[under_thresh_indices] = 0

--- a/evaluation.py
+++ b/evaluation.py
@@ -109,9 +109,9 @@ class Evaluation():
         for i in range(NUM_COCO_KEYPOINTS):
             hmap = heatmaps[:,:,i]
             # Resize heatmap from Output DIM to Input DIM
-            resized_hmap = cv2.resize(hmap, INPUT_DIM, interpolation = cv2.INTER_AREA)
+            resized_hmap = cv2.resize(hmap, INPUT_DIM, interpolation = cv2.INTER_LINEAR)
             # Do a heatmap blur with gaussian_filter
-            resized_hmap = gaussian_filter(resized_hmap, HEATMAP_SIGMA)
+            resized_hmap = gaussian_filter(resized_hmap, REVERSE_HEATMAP_SIGMA)
 
             # Get peak point (brightest area) in heatmap with 3x3 max filter
             peaks = self._non_max_supression(resized_hmap, threshold, windowSize=3)
@@ -119,8 +119,8 @@ class Evaluation():
             # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
             # and get its coordinates and confidence
             y, x = np.where(peaks == peaks.max())
-            if len(x) > 0 and len(y) > 0:
-                keypoints.append((int(x[0]), int(y[0]), peaks[y[0], x[0]]))
+            if int(x[0]) > 0 and int(y[0]) > 0:
+                keypoints.append((int(x[0]), int(y[0]), 1))
             else:
                 keypoints.append((0, 0, 0))
         # Turn keypoints into np array

--- a/evaluation.py
+++ b/evaluation.py
@@ -105,7 +105,7 @@ class Evaluation():
     # https://github.com/david8862/tf-keras-stacked-hourglass-keypoint-detection/blob/56707252501c73b2bf2aac8fff3e22760fd47dca/hourglass/postprocess.py#L17
    
     ### Returns np array of predicted keypoints from one image's heatmaps
-    def heatmaps_to_keypoints(self, heatmaps, threshold=0.05):
+    def heatmaps_to_keypoints(self, heatmaps, threshold=HM_TO_KP_THRESHOLD):
         keypoints = list()
         for i in range(NUM_COCO_KEYPOINTS):
             hmap = heatmaps[:,:,i]
@@ -115,7 +115,7 @@ class Evaluation():
             resized_hmap = gaussian_filter(resized_hmap, HEATMAP_SIGMA)
 
             # Get peak point (brightest area) in heatmap with 3x3 max filter
-            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=0.05)
+            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=HM_TO_KP_THRESHOLD)
 
             # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
             # and get its coordinates and confidence
@@ -128,7 +128,7 @@ class Evaluation():
         keypoints = np.array(keypoints)
         return keypoints
 
-    def _non_max_supression(self, plain, windowSize=3, threshold=0.05):
+    def _non_max_supression(self, plain, windowSize=3, threshold=HM_TO_KP_THRESHOLD):
         # Clear values less than threshold
         under_thresh_indices = plain < threshold
         plain[under_thresh_indices] = 0

--- a/evaluation.py
+++ b/evaluation.py
@@ -105,18 +105,17 @@ class Evaluation():
     # https://github.com/david8862/tf-keras-stacked-hourglass-keypoint-detection/blob/56707252501c73b2bf2aac8fff3e22760fd47dca/hourglass/postprocess.py#L17
    
     ### Returns np array of predicted keypoints from one image's heatmaps
-    def heatmaps_to_keypoints(self, heatmaps, threshold=1e-2):
+    def heatmaps_to_keypoints(self, heatmaps, threshold=0.05):
         keypoints = list()
         for i in range(NUM_COCO_KEYPOINTS):
             hmap = heatmaps[:,:,i]
-            
-            # Do a heatmap blur with gaussian_filter
-            hmap = gaussian_filter(hmap, HEATMAP_SIGMA)
-             # Resize heatmap from Output DIM to Input DIM
+            # Resize heatmap from Output DIM to Input DIM
             resized_hmap = cv2.resize(hmap, INPUT_DIM, interpolation = cv2.INTER_AREA)
+            # Do a heatmap blur with gaussian_filter
+            resized_hmap = gaussian_filter(resized_hmap, HEATMAP_SIGMA)
 
             # Get peak point (brightest area) in heatmap with 3x3 max filter
-            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=1e-2)
+            peaks = self._non_max_supression(resized_hmap, windowSize=3, threshold=0.05)
 
             # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
             # and get its coordinates and confidence
@@ -127,10 +126,9 @@ class Evaluation():
                 keypoints.append((0, 0, 0))
         # Turn keypoints into np array
         keypoints = np.array(keypoints)
-        print(keypoints)
         return keypoints
 
-    def _non_max_supression(self, plain, windowSize=3, threshold=1e-2):
+    def _non_max_supression(self, plain, windowSize=3, threshold=0.05):
         # Clear values less than threshold
         under_thresh_indices = plain < threshold
         plain[under_thresh_indices] = 0

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,11 +1,6 @@
-<<<<<<< HEAD
 import cv2
-=======
-from HeatMap import HeatMap # https://github.com/LinShanify/HeatMap
-from constants import *
 from scipy.ndimage import gaussian_filter, maximum_filter
 
->>>>>>> Added heatmap to keypoint functionality
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -18,8 +18,8 @@ train_df, val_df = h.load_and_filter_annotations(DEFAULT_TRAIN_ANNOT_PATH,DEFAUL
 # %% Declare evaluation class instance
 eval = Evaluation(
     # ensure model_json and weights files exist in current directory and num_hg_blocks matches model_json
-    model_json='hpe_hourglass_stacks_04_batchsize_012.json',
-    weights='hpe_epoch71_val_loss_0.0417_train_loss_0.0163.hdf5',
+    model_json='models/hpe_hourglass_stacks_04_batchsize_012.json',
+    weights='models/hpe_epoch71_val_loss_0.0417_train_loss_0.0163.hdf5',
     df=val_df,
     num_hg_blocks=DEFAULT_NUM_HG,
     batch_size=1)
@@ -48,4 +48,45 @@ filename = 'heatmap_evaluation.png'
 eval.save_stacked_evaluation_heatmaps(h, X, y, stacked_predict_heatmaps_file, stacked_ground_truth_heatmaps_file, filename)
 print(f"Saved stacked evaluation heatmaps as {filename} to disk")
 
+# %% Plot predicted keypoints from heatmaps on bounding box image
+import numpy as np
+from HeatMap import HeatMap
+
+generator = DataGenerator(
+            df=val_df,
+            base_dir=DEFAULT_VAL_IMG_PATH,
+            input_dim=INPUT_DIM,
+            output_dim=OUTPUT_DIM,
+            num_hg_blocks=DEFAULT_NUM_HG,
+            shuffle=False,  
+            batch_size=1,
+            online_fetch=False)
+
+# Select image to predict heatmaps
+X_batch, y_stacked = generator[168] # choose one image for evaluation
+y_batch = y_stacked[0] # take first hourglass section
+X, y = X_batch[0], y_batch[0] # take first example of batch
+
+# Get predicted heatmaps for image
+predict_heatmaps=eval.predict_heatmaps(h, X)
+
+# Get predicted keypoints from last hourglass (eval.num_hg_blocks-1)
+keypoints = eval.heatmaps_to_keypoints(predict_heatmaps[eval.num_hg_blocks-1, 0, :, :, :])
+
+# Get bounding box image from heatmap
+heatmap = y[:,:,0]
+hm = HeatMap(X,heatmap)
+img = np.array(hm.image)
+
+# Clear plot image
+plt.clf()
+# Plot predicted keypoints on bounding box image
+x = []
+y = []
+for i in range(NUM_COCO_KEYPOINTS):
+    if(keypoints[i,0] != 0 and keypoints[i,1] != 0):
+      x.append(keypoints[i,0])
+      y.append(keypoints[i,1])
+plt.plot(x,y)
+plt.imshow(img)
 # %%

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -87,6 +87,6 @@ for i in range(NUM_COCO_KEYPOINTS):
     if(keypoints[i,0] != 0 and keypoints[i,1] != 0):
       x.append(keypoints[i,0])
       y.append(keypoints[i,1])
-plt.plot(x,y)
+plt.scatter(x,y)
 plt.imshow(img)
 # %%

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -18,8 +18,8 @@ train_df, val_df = h.load_and_filter_annotations(DEFAULT_TRAIN_ANNOT_PATH,DEFAUL
 # %% Declare evaluation class instance
 eval = Evaluation(
     # ensure model_json and weights files exist in current directory and num_hg_blocks matches model_json
-    model_json='models/hpe_hourglass_stacks_04_batchsize_012.json',
-    weights='models/hpe_epoch71_val_loss_0.0417_train_loss_0.0163.hdf5',
+    model_json='hpe_hourglass_stacks_04_batchsize_012.json',
+    weights='hpe_epoch71_val_loss_0.0417_train_loss_0.0163.hdf5',
     df=val_df,
     num_hg_blocks=DEFAULT_NUM_HG,
     batch_size=1)


### PR DESCRIPTION
This PR adds the functionality for getting predicted keypoints from our predicted heatmaps output.

To test I have plotted the predicted keypoints onto the bounding box image.

@Airborne95 will follow up with a PR to transfer these keypoints back to the original image's scale.

Props to "test lady Janine"
![img](https://user-images.githubusercontent.com/43253618/112731033-23df5200-8ef2-11eb-9348-7ac0b70626b2.png)
