### PR TITLE
Enable reusing the same subdirectory for model resumes **only if** it is resuming the latest epoch file

### DIFF
--- a/hourglass.py
+++ b/hourglass.py
@@ -97,10 +97,10 @@ class HourglassNet(object):
         logsDir = os.path.join(DEFAULT_LOGS_BASE_DIR, model_subdir)
 
         # If this path is changed, the corresponding logic to resume should be updated in util.py
-        modelSavePath = os.path.join(modelDir, '{prefix}{{epoch:02d}}_val_loss_{{val_loss:.4f}}_train_loss_{{loss:.4f}}.hdf5'.format(prefix=HPE_EPOCH_PREFIX))
+        modelSavePath = os.path.join(modelDir, f'{HPE_EPOCH_PREFIX}{{epoch:02d}}_val_loss_{{val_loss:.4f}}_train_loss_{{loss:.4f}}.hdf5')
 
         if not os.path.exists(modelDir):
-            print("Model save directory created: {}".format(modelDir))
+            print(f"Model save directory created: {modelDir}")
             os.makedirs(modelDir)
 
         # Create callbacks
@@ -113,13 +113,13 @@ class HourglassNet(object):
 
         callbacks = [mc_val, mc_train, tb, csv_logger]
 
-        architecture_json_file = os.path.join(modelDir, '{}_{:02d}_batchsize_{:03d}.json'.format(HPE_HOURGLASS_STACKS_PREFIX, self.num_stacks, batch_size))
+        architecture_json_file = os.path.join(modelDir, f'{HPE_HOURGLASS_STACKS_PREFIX}_{self.num_stacks:02d}_batchsize_{batch_size:03d}.json')
         if not os.path.exists(architecture_json_file):
             with open(architecture_json_file, 'w') as f:
-                print("Model architecture json saved to: {}".format(architecture_json_file))
+                print(f"Model architecture json saved to:   {architecture_json_file}")
                 f.write(self.model.to_json())
 
-        print("Model checkpoints saved to: {}".format(modelSavePath))
+        print(f"Model checkpoints saved to:         {modelSavePath}")
 
         self.model.fit_generator(generator=train_generator, validation_data=val_generator, steps_per_epoch=len(train_generator), \
             validation_steps=len(val_generator), epochs=epochs, initial_epoch=initial_epoch, callbacks=callbacks)
@@ -144,8 +144,8 @@ class HourglassNet(object):
         if resume_subdir is not None:
             print('Automatically locating model architecture .json and weights .hdf5...')
 
-        print('Restoring model architecture json: {}'.format(model_json))
-        print('Restoring model weights: {}'.format(model_weights))
+        print(f'Restoring model architecture json:  {model_json}')
+        print(f'Restoring model weights:            {model_weights}')
 
         # NOTE, make sure loss function matches
         self._load_model(model_json, model_weights)

--- a/hourglass.py
+++ b/hourglass.py
@@ -140,7 +140,7 @@ class HourglassNet(object):
         self._start_train(batch_size=batch_size, model_base_dir=model_save_base_dir, epochs=epochs, \
             initial_epoch=0, model_subdir=model_subdir, current_time=current_time, subset=subset)
 
-    def resume_train(self, batch_size, model_save_base_dir, model_json, model_weights, init_epoch, epochs, resume_subdir, subset):
+    def resume_train(self, batch_size, model_save_base_dir, model_json, model_weights, init_epoch, epochs, resume_subdir, subset, new_run=True):
         if resume_subdir is not None:
             print('Automatically locating model architecture .json and weights .hdf5...')
 
@@ -160,7 +160,10 @@ class HourglassNet(object):
             # strip everything after resume flag
             orig_model_subdir = orig_model_subdir[:orig_model_subdir.find(DEFAULT_RESUME_DIR_FLAG)]
 
-        model_subdir = orig_model_subdir + DEFAULT_RESUME_DIR_FLAG + current_time
+        model_subdir = orig_model_subdir
+
+        if new_run:
+            model_subdir += DEFAULT_RESUME_DIR_FLAG + current_time
 
         self._start_train(batch_size=batch_size, model_base_dir=model_save_base_dir, epochs=epochs, \
             initial_epoch=init_epoch, model_subdir=model_subdir, current_time=current_time, subset=subset)

--- a/hourglass.py
+++ b/hourglass.py
@@ -145,7 +145,7 @@ class HourglassNet(object):
             print('Automatically locating model architecture .json and weights .hdf5...')
 
         print(f'Restoring model architecture json:  {model_json}')
-        print(f'Restoring model weights:            {model_weights}')
+        print(f'Restoring model weights:            {model_weights}\n')
 
         # NOTE, make sure loss function matches
         self._load_model(model_json, model_weights)
@@ -163,6 +163,7 @@ class HourglassNet(object):
         model_subdir = orig_model_subdir
 
         if new_run:
+            print("Resuming with a new session ID...\n")
             model_subdir += DEFAULT_RESUME_DIR_FLAG + current_time
 
         self._start_train(batch_size=batch_size, model_base_dir=model_save_base_dir, epochs=epochs, \

--- a/train.py
+++ b/train.py
@@ -126,7 +126,7 @@ def process_args():
         # which may cause the graph to no longer be single-valued.
         # See https://github.com/tensorflow/tensorboard/issues/3732
         if not args.resume_with_new_run:
-            args.resume_with_new_run = is_highest_epoch_file(args.resume_json, args.resume_weights, args.resume_epoch)
+            args.resume_with_new_run = not is_highest_epoch_file(args.model_save, args.resume_subdir, args.resume_epoch)
 
         assert args.resume_json is not None and args.resume_weights is not None, \
             "Resume model training enabled, but no parameters received for: --resume-subdir, or both --resume-json and --resume-weights"

--- a/train.py
+++ b/train.py
@@ -116,7 +116,7 @@ def process_args():
     if args.resume:
         # Automatically locate architecture json and model weights
         if args.resume_subdir is not None:
-            find_resume_json_weights_args(args)
+            args.resume_json, args.resume_weights, args.resume_epoch = find_resume_json_weights_str(args.model_save, args.resume_subdir, args.resume_epoch)
 
         assert args.resume_json is not None and args.resume_weights is not None, \
             "Resume model training enabled, but no parameters received for: --resume-subdir, or both --resume-json and --resume-weights"

--- a/util.py
+++ b/util.py
@@ -35,7 +35,7 @@ def is_highest_epoch_file(model_base_dir, model_subdir, epoch_):
 
             if epoch > epoch_:
                 return False
-    
+
     return True
 
 def find_resume_json_weights_str(model_base_dir, model_subdir, resume_epoch):
@@ -63,8 +63,8 @@ def find_resume_json_weights_str(model_base_dir, model_subdir, resume_epoch):
     resume_json = os.path.join(enclosing_dir, model_jsons[0])
     resume_weights = os.path.join(enclosing_dir, model_saved_weights[resume_epoch])
 
-    print('Found model json: {}'.format(resume_json))
-    print('Found model weights for epoch {epoch:02d}: {weight_file_name}'.format(epoch=resume_epoch, weight_file_name=resume_weights))
+    print('Found model json:                  {}'.format(resume_json))
+    print('Found model weights for epoch {epoch:03d}: {weight_file_name}'.format(epoch=resume_epoch, weight_file_name=resume_weights))
 
     assert os.path.exists(resume_json)
     assert os.path.exists(resume_weights)

--- a/util.py
+++ b/util.py
@@ -22,8 +22,21 @@ def validate_enum(EnumClass, str):
         exit(1)
     return True
 
-def find_resume_json_weights_args(args):
-    args.resume_json, args.resume_weights, args.resume_epoch = find_resume_json_weights_str(args.model_save, args.resume_subdir, args.resume_epoch)
+def is_highest_epoch_file(model_base_dir, model_subdir, epoch_):
+    enclosing_dir = os.path.join(model_base_dir, model_subdir)
+
+    files = os.listdir(enclosing_dir)
+
+    for f in files:
+        match = re.match(f'^{HPE_EPOCH_PREFIX}([\d]+).*\.hdf5$', f)
+
+        if match:
+            epoch = int(match.group(1))
+
+            if epoch > epoch_:
+                return False
+    
+    return True
 
 def find_resume_json_weights_str(model_base_dir, model_subdir, resume_epoch):
     enclosing_dir = os.path.join(model_base_dir, model_subdir)


### PR DESCRIPTION
This adds logic to reuse the same training session ID on resuming training, under the precondition that the model is resuming the newest epoch weight file. This is to avoid weird problems with Tensorboard logs when resuming from an earlier epoch. 

This also refactors all `.format()` in `hourglass.py` to use `f` formatting.