### PR TITLE
Add ability to load any arbitrary image, centered on human, of any aspect ratio

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -190,7 +190,7 @@ def load_and_preprocess_img(img_path, num_hg_blocks, bbox=None):
     X_batch = np.expand_dims(new_img.astype('float'), axis=0)
 
     # Add dummy heatmap "ground truth", duplicated 'num_hg_blocks' times
-    y_batch = [np.zeros((1, *(OUTPUT_DIM), NUM_COCO_KEYPOINTS)) for _ in range(num_hg_blocks)]
+    y_batch = [np.zeros((1, *(OUTPUT_DIM), NUM_COCO_KEYPOINTS), dtype='float') for _ in range(num_hg_blocks)]
 
     # Normalize input image
     X_batch /= 255

--- a/evaluation.py
+++ b/evaluation.py
@@ -4,7 +4,7 @@ import cv2
 from scipy.ndimage import gaussian_filter, maximum_filter
 import matplotlib.pyplot as plt
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 
 from constants import *
 import HeatMap  # https://github.com/LinShanify/HeatMap
@@ -161,10 +161,29 @@ x,y,w,h : {int or float} optional bounding box info, anchored at top left of ima
 def load_and_preprocess_img(img_path, num_hg_blocks, x=None, y=None, w=None, h=None):
     img = Image.open(img_path).convert('RGB')
 
+    # Required because PIL will read EXIF tags about rotation by default. We want to 
+    # preserve the input image rotation so we manually apply the rotation if required.
+    # See https://stackoverflow.com/questions/4228530/pil-thumbnail-is-rotating-my-image/
+    # and the answer I used: https://stackoverflow.com/a/63798032
+    img = ImageOps.exif_transpose(img)
+    plt.imshow(img)
+    plt.show()
+
     if x is None or y is None or w is None or h is None:
-        # If any of the parameters are missing, crop a square area from top left of image
-        smaller_dim = img.size[0] if img.size[0] <= img.size[1] else img.size[1]
-        bbox = [0, 0, smaller_dim, smaller_dim]
+        h, w = img.size
+
+        center_x = w/2
+        center_y = h/2
+        if w >= h:
+            new_w = w
+            new_h = w * INPUT_DIM[1]/INPUT_DIM[0]
+        else:
+            new_w = h * INPUT_DIM[0]/INPUT_DIM[1]
+            new_h = h
+
+        new_x = center_x - new_w/2
+        new_y = center_y - new_h/2
+        bbox = [round(new_x), round(new_y), round(new_x+new_w), round(new_y+new_h)]
     else:
         # If a bounding box is provided, use it
         bbox = [x, y, w, h]
@@ -172,6 +191,9 @@ def load_and_preprocess_img(img_path, num_hg_blocks, x=None, y=None, w=None, h=N
     bbox = np.array(bbox)
 
     cropped_img = img.crop(box=bbox)
+    plt.imshow(cropped_img)
+    plt.show()
+    
     cropped_width, cropped_height = cropped_img.size
     new_img = cv2.resize(np.array(cropped_img), INPUT_DIM,
                         interpolation=cv2.INTER_LINEAR)

--- a/evaluation.py
+++ b/evaluation.py
@@ -89,11 +89,11 @@ class Evaluation():
             y = y_batch[i,]
             m = m_batch[i]
             predicted_heatmaps = predicted_heatmaps_batch[:,i,]
-            self.save_stacked_evaluation_heatmaps(X, y, m, predicted_heatmaps)
+            self.save_stacked_evaluation_heatmaps(X, y, str(m['ann_id']) + '.png', predicted_heatmaps)
 
 
     #  Saves to disk stacked predicted heatmaps and stacked ground truth heatmaps and one evaluation image
-    def save_stacked_evaluation_heatmaps(self, X, y, m, predicted_heatmaps):
+    def save_stacked_evaluation_heatmaps(self, X, y, filename, predicted_heatmaps):
         stacked_predict_heatmaps=self.stacked_predict_heatmaps(predicted_heatmaps)
         stacked_ground_truth_heatmaps=self.stacked_ground_truth_heatmaps(X, y)
 
@@ -111,7 +111,6 @@ class Evaluation():
         # Resize and vertically stack heatmap images
         img_v_resize = self._vstack_images(heatmap_imgs)
 
-        filename = str(m['ann_id']) + '.png'
         cv2.imwrite(os.path.join(self.output_sub_dir,filename), img_v_resize)
 
     # Resources for heatmaps to keypoints

--- a/hourglass.py
+++ b/hourglass.py
@@ -100,7 +100,7 @@ class HourglassNet(object):
         modelSavePath = os.path.join(modelDir, f'{HPE_EPOCH_PREFIX}{{epoch:02d}}_val_loss_{{val_loss:.4f}}_train_loss_{{loss:.4f}}.hdf5')
 
         if not os.path.exists(modelDir):
-            print(f"Model save directory created: {modelDir}")
+            print(f"Model save directory created:       {modelDir}")
             os.makedirs(modelDir)
 
         # Create callbacks

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -6,6 +6,7 @@ from hourglass import HourglassNet
 from constants import *
 import matplotlib.pyplot as plt
 import os
+%matplotlib inline
 
 h = HourglassNet(NUM_COCO_KEYPOINTS,DEFAULT_NUM_HG,INPUT_CHANNELS,INPUT_DIM,OUTPUT_DIM)
 _, val_df = h.load_and_filter_annotations(DEFAULT_TRAIN_ANNOT_PATH,DEFAULT_VAL_ANNOT_PATH,0.1)
@@ -16,6 +17,7 @@ import evaluation
 import HeatMap
 imp.reload(evaluation)
 imp.reload(HeatMap)
+# %%
 
 representative_set_df = pd.read_pickle(os.path.join(DEFAULT_PICKLE_PATH, 'representative_set.pkl'))
 subdir = '2021-03-22-20h-23m_batchsize_12_hg_8_loss_weighted_mse_aug_medium_resume_2021-03-25-20h-02m'
@@ -64,7 +66,9 @@ generator = data_generator.DataGenerator(
             online_fetch=False)
 
 # Select image to predict heatmaps
-X_batch, y_stacked = generator[168] # choose one image for evaluation
+# X_batch, y_stacked = generator[168] # choose one image for evaluation
+img_name = 'IMG_1830.jpg'
+X_batch, y_stacked = evaluation.load_and_preprocess_img(os.path.join('data', img_name), DEFAULT_NUM_HG)
 y_batch = y_stacked[0] # take first hourglass section
 X, y = X_batch[0], y_batch[0] # take first example of batch
 
@@ -90,4 +94,7 @@ for i in range(NUM_COCO_KEYPOINTS):
       y.append(keypoints[i,1])
 plt.scatter(x,y)
 plt.imshow(img)
+
+nm = img_name.split('.')[0]
+plt.savefig(os.path.join(DEFAULT_OUTPUT_BASE_DIR, f'{nm}_saved_scatter.png'))
 # %%

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -55,10 +55,13 @@ import numpy as np
 from HeatMap import HeatMap
 
 # Select image to predict heatmaps
-# X_batch, y_stacked = generator[168] # choose one image for evaluation
-img_name = 'IMG_3274.jpg'
-name_no_extension = img_name.split('.')[0]
-X_batch, y_stacked = evaluation.load_and_preprocess_img(os.path.join('data', img_name), eval.num_hg_blocks)
+X_batch, y_stacked = generator[168] # choose one image for evaluation
+name_no_extension = "tmp"
+
+## Uncomment below for arbitrary images
+# img_name = 'IMG_3274.jpg'
+# name_no_extension = img_name.split('.')[0]
+# X_batch, y_stacked = evaluation.load_and_preprocess_img(os.path.join('data', img_name), eval.num_hg_blocks)
 y_batch = y_stacked[0] # take first hourglass section
 X, y = X_batch[0], y_batch[0] # take first example of batch
 

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -6,7 +6,7 @@ from hourglass import HourglassNet
 from constants import *
 import matplotlib.pyplot as plt
 import os
-%matplotlib inline
+# %matplotlib inline
 
 h = HourglassNet(NUM_COCO_KEYPOINTS,DEFAULT_NUM_HG,INPUT_CHANNELS,INPUT_DIM,OUTPUT_DIM)
 _, val_df = h.load_and_filter_annotations(DEFAULT_TRAIN_ANNOT_PATH,DEFAULT_VAL_ANNOT_PATH,0.1)

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -28,7 +28,6 @@ eval = evaluation.Evaluation(
 # %% Save stacked evaluation heatmaps
 import data_generator
 imp.reload(data_generator)
-import data_generator
 import time
 
 generator = data_generator.DataGenerator(
@@ -55,20 +54,11 @@ print("\n\nEval end:   {}\n".format(time.ctime()))
 import numpy as np
 from HeatMap import HeatMap
 
-generator = data_generator.DataGenerator(
-            df=val_df,
-            base_dir=DEFAULT_VAL_IMG_PATH,
-            input_dim=INPUT_DIM,
-            output_dim=OUTPUT_DIM,
-            num_hg_blocks=DEFAULT_NUM_HG,
-            shuffle=False,
-            batch_size=1,
-            online_fetch=False)
-
 # Select image to predict heatmaps
 # X_batch, y_stacked = generator[168] # choose one image for evaluation
-img_name = 'IMG_1830.jpg'
-X_batch, y_stacked = evaluation.load_and_preprocess_img(os.path.join('data', img_name), DEFAULT_NUM_HG)
+img_name = 'IMG_3274.jpg'
+name_no_extension = img_name.split('.')[0]
+X_batch, y_stacked = evaluation.load_and_preprocess_img(os.path.join('data', img_name), eval.num_hg_blocks)
 y_batch = y_stacked[0] # take first hourglass section
 X, y = X_batch[0], y_batch[0] # take first example of batch
 
@@ -95,6 +85,5 @@ for i in range(NUM_COCO_KEYPOINTS):
 plt.scatter(x,y)
 plt.imshow(img)
 
-nm = img_name.split('.')[0]
-plt.savefig(os.path.join(DEFAULT_OUTPUT_BASE_DIR, f'{nm}_saved_scatter.png'))
+plt.savefig(os.path.join(DEFAULT_OUTPUT_BASE_DIR, f'{name_no_extension}_saved_scatter.png'))
 # %%

--- a/util.py
+++ b/util.py
@@ -63,8 +63,8 @@ def find_resume_json_weights_str(model_base_dir, model_subdir, resume_epoch):
     resume_json = os.path.join(enclosing_dir, model_jsons[0])
     resume_weights = os.path.join(enclosing_dir, model_saved_weights[resume_epoch])
 
-    print('Found model json:                  {}'.format(resume_json))
-    print('Found model weights for epoch {epoch:03d}: {weight_file_name}'.format(epoch=resume_epoch, weight_file_name=resume_weights))
+    print('Found model json:                  {}\n'.format(resume_json))
+    print('Found model weights for epoch {epoch:3d}: {weight_file_name}\n'.format(epoch=resume_epoch, weight_file_name=resume_weights))
 
     assert os.path.exists(resume_json)
     assert os.path.exists(resume_weights)


### PR DESCRIPTION
This PR mainly adds support for loading arbitrary images and visualizing the predicted keypoints.

This PR refactors the bounding box transformation logic out of the data gen class to reuse for arbitrary img. I removed the arbitrary aspect ratio functionality because it was getting too complicated to get it working. 

## TODO
If anyone has capacity, please consider helping with these: 

* Verify that `ImageOps.exif_transpose(img)` is not needed in our data gen. If the PIL Image.read sees EXIF data about rotations applied to the image, it doesn't apply those, so we may be feeding rotated 90 degree images to the model. We should validate on the validation dataset that this EXIF is not present.
* It would be nice to pass in a directory of images, and the we auto read and predict on them
* visualizing heat maps doesn't work here yet. Not sure why. I tried to get to the bottom of this but ran out of time.