### PR TITLE
Add PCK Evaluation

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -96,6 +96,7 @@ BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 
 # Output filtering constants
 HM_TO_KP_THRESHOLD = 0.2
+PCK_THRESHOLD = 0.2
 
 # Data aug flip R/L probability
 RL_FLIP = 0.5

--- a/evaluation.py
+++ b/evaluation.py
@@ -242,8 +242,8 @@ class Evaluation():
     # This function evaluates PCK@0.2 == Distance between predicted and true joint < 0.2 * torso diameter
     # The PCK_THRESHOLD constant can be updated to adjust this threshold
     # https://github.com/cbsudux/Human-Pose-Estimation-101#percentage-of-correct-key-points---pck
-    def pck_eval(self, generator, location, annotation_file):
-        _, list_of_predictions = self.predict_keypoints(generator, location)
+    def pck_eval(self, generator, save_location, annotation_file):
+        _, list_of_predictions = self.predict_keypoints(generator, save_location)
         f = open(annotation_file)
         data = json.load(f)
 
@@ -294,63 +294,63 @@ class Evaluation():
             # Each image may have more than one annotation we need to check
             annotations = int(len(dist_list)/NUM_COCO_KEYPOINTS)
 
-            nose_correct = []
-            left_eye_correct = []
-            right_eye_correct = []
-            left_ear_correct = []
-            right_ear_correct = []
-            left_shoulder_correct = []
-            right_shoulder_correct = []
-            left_elbow_correct = []
-            right_elbow_correct = []
-            left_wrist_correct = []
-            right_wrist_correct = []
-            left_hip_correct = []
-            right_hip_correct = []
-            left_knee_correct = []
-            right_knee_correct = []
-            left_ankle_correct = []
-            right_ankle_correct = []
+            nose_correct = False
+            left_eye_correct = False
+            right_eye_correct = False
+            left_ear_correct = False
+            right_ear_correct = False
+            left_shoulder_correct = False
+            right_shoulder_correct = False
+            left_elbow_correct = False
+            right_elbow_correct = False
+            left_wrist_correct = False
+            right_wrist_correct = False
+            left_hip_correct = False
+            right_hip_correct = False
+            left_knee_correct = False
+            right_knee_correct = False
+            left_ankle_correct = False
+            right_ankle_correct = False
 
             # Append True to correct joint list if distance is below threshold for any annotation
             for j in range(annotations):
                 base = j*NUM_COCO_KEYPOINTS
-                nose_correct.append(dist_list[0+base]<=threshold)
-                left_eye_correct.append(dist_list[1+base]<=threshold)
-                right_eye_correct.append(dist_list[2+base]<=threshold)
-                left_ear_correct.append(dist_list[3+base]<=threshold)
-                right_ear_correct.append(dist_list[4+base]<=threshold)
-                left_shoulder_correct.append(dist_list[5+base]<=threshold)
-                right_shoulder_correct.append(dist_list[6+base]<=threshold)
-                left_elbow_correct.append(dist_list[7+base]<=threshold)
-                right_elbow_correct.append(dist_list[8+base]<=threshold)
-                left_wrist_correct.append(dist_list[9+base]<=threshold)
-                right_wrist_correct.append(dist_list[10+base]<=threshold)
-                left_hip_correct.append(dist_list[11+base]<=threshold)
-                right_hip_correct.append(dist_list[12+base]<=threshold)
-                left_knee_correct.append(dist_list[13+base]<=threshold)
-                right_knee_correct.append(dist_list[14+base]<=threshold)
-                left_ankle_correct.append(dist_list[15+base]<=threshold)
-                right_ankle_correct.append(dist_list[16+base]<=threshold)
+                if dist_list[0+base]<=threshold: nose_correct = True
+                if dist_list[1+base]<=threshold: left_eye_correct = True
+                if dist_list[2+base]<=threshold: right_eye_correct = True
+                if dist_list[3+base]<=threshold: left_ear_correct = True
+                if dist_list[4+base]<=threshold: right_ear_correct = True
+                if dist_list[5+base]<=threshold: left_shoulder_correct = True
+                if dist_list[6+base]<=threshold: right_shoulder_correct = True
+                if dist_list[7+base]<=threshold: left_elbow_correct = True
+                if dist_list[8+base]<=threshold: right_elbow_correct = True
+                if dist_list[9+base]<=threshold: left_wrist_correct = True
+                if dist_list[10+base]<=threshold: right_wrist_correct = True
+                if dist_list[11+base]<=threshold: left_hip_correct = True
+                if dist_list[12+base]<=threshold: right_hip_correct = True
+                if dist_list[13+base]<=threshold: left_knee_correct = True
+                if dist_list[14+base]<=threshold: right_knee_correct = True
+                if dist_list[15+base]<=threshold: left_ankle_correct = True
+                if dist_list[16+base]<=threshold: right_ankle_correct = True
 
             # Add one to correct keypoint count if any annotation was below threshold for image
-            if True in nose_correct: correct_keypoints["nose"] += 1
-            if True in left_eye_correct: correct_keypoints["left_eye"] += 1
-            if True in right_eye_correct: correct_keypoints["right_eye"] += 1
-            if True in left_ear_correct: correct_keypoints["left_ear"] += 1
-            if True in right_ear_correct: correct_keypoints["right_ear"] += 1
-            if True in left_shoulder_correct: correct_keypoints["left_shoulder"] += 1
-            if True in right_shoulder_correct: correct_keypoints["right_shoulder"] += 1
-            if True in left_elbow_correct: correct_keypoints["left_elbow"] += 1
-            if True in right_elbow_correct: correct_keypoints["right_elbow"] += 1
-            if True in left_wrist_correct: correct_keypoints["left_wrist"] += 1
-            if True in right_wrist_correct: correct_keypoints["right_wrist"] += 1
-            if True in left_hip_correct: correct_keypoints["left_hip"] += 1
-            if True in right_hip_correct: correct_keypoints["right_hip"] += 1
-            if True in left_knee_correct: correct_keypoints["left_knee"] += 1
-            if True in right_knee_correct: correct_keypoints["right_knee"] += 1
-            if True in left_ankle_correct: correct_keypoints["left_ankle"] += 1
-            if True in right_ankle_correct: correct_keypoints["right_ankle"] += 1
+            if nose_correct: correct_keypoints["nose"] += 1
+            if left_eye_correct: correct_keypoints["left_eye"] += 1
+            if right_eye_correct: correct_keypoints["right_eye"] += 1
+            if left_ear_correct: correct_keypoints["left_ear"] += 1
+            if right_ear_correct: correct_keypoints["right_ear"] += 1
+            if left_shoulder_correct: correct_keypoints["left_shoulder"] += 1
+            if right_shoulder_correct: correct_keypoints["right_shoulder"] += 1
+            if left_elbow_correct: correct_keypoints["left_elbow"] += 1
+            if right_elbow_correct: correct_keypoints["right_elbow"] += 1
+            if left_wrist_correct: correct_keypoints["left_wrist"] += 1
+            if right_wrist_correct: correct_keypoints["right_wrist"] += 1
+            if left_hip_correct: correct_keypoints["left_hip"] += 1
+            if right_hip_correct: correct_keypoints["right_hip"] += 1
+            if left_knee_correct: correct_keypoints["left_knee"] += 1
+            if right_knee_correct: correct_keypoints["right_knee"] += 1
+            if left_ankle_correct: correct_keypoints["left_ankle"] += 1
+            if right_ankle_correct: correct_keypoints["right_ankle"] += 1
             dist_list = []
 
         samples = len(list_of_predictions)

--- a/evaluation.py
+++ b/evaluation.py
@@ -285,7 +285,7 @@ class Evaluation():
                     threshold = PCK_THRESHOLD*torso
 
                     for i in range(NUM_COCO_KEYPOINTS):
-                        base = i*3
+                        base = i * NUM_COCO_KP_ATTRBS
                         prediction_point = np.array(prediction_keypoints[base], prediction_keypoints[base+1])
                         annotation_point = np.array(annotation_keypoints[base], annotation_keypoints[base+1])
                         dist = (np.linalg.norm(prediction_point-annotation_point))
@@ -314,7 +314,7 @@ class Evaluation():
 
             # Append True to correct joint list if distance is below threshold for any annotation
             for j in range(annotations):
-                base = j*NUM_COCO_KEYPOINTS
+                base = j * NUM_COCO_KEYPOINTS
                 if dist_list[0+base]<=threshold: nose_correct = True
                 if dist_list[1+base]<=threshold: left_eye_correct = True
                 if dist_list[2+base]<=threshold: right_eye_correct = True

--- a/evaluation.py
+++ b/evaluation.py
@@ -315,23 +315,23 @@ class Evaluation():
             # Append True to correct joint list if distance is below threshold for any annotation
             for j in range(annotations):
                 base = j * NUM_COCO_KEYPOINTS
-                if dist_list[0+base]<=threshold: nose_correct = True
-                if dist_list[1+base]<=threshold: left_eye_correct = True
-                if dist_list[2+base]<=threshold: right_eye_correct = True
-                if dist_list[3+base]<=threshold: left_ear_correct = True
-                if dist_list[4+base]<=threshold: right_ear_correct = True
-                if dist_list[5+base]<=threshold: left_shoulder_correct = True
-                if dist_list[6+base]<=threshold: right_shoulder_correct = True
-                if dist_list[7+base]<=threshold: left_elbow_correct = True
-                if dist_list[8+base]<=threshold: right_elbow_correct = True
-                if dist_list[9+base]<=threshold: left_wrist_correct = True
-                if dist_list[10+base]<=threshold: right_wrist_correct = True
-                if dist_list[11+base]<=threshold: left_hip_correct = True
-                if dist_list[12+base]<=threshold: right_hip_correct = True
-                if dist_list[13+base]<=threshold: left_knee_correct = True
-                if dist_list[14+base]<=threshold: right_knee_correct = True
-                if dist_list[15+base]<=threshold: left_ankle_correct = True
-                if dist_list[16+base]<=threshold: right_ankle_correct = True
+                nose_correct            = nose_correct              or dist_list[0+base]  <= threshold
+                left_eye_correct        = left_eye_correct          or dist_list[1+base]  <= threshold
+                right_eye_correct       = right_eye_correct         or dist_list[2+base]  <= threshold
+                left_ear_correct        = left_ear_correct          or dist_list[3+base]  <= threshold
+                right_ear_correct       = right_ear_correct         or dist_list[4+base]  <= threshold
+                left_shoulder_correct   = left_shoulder_correct     or dist_list[5+base]  <= threshold
+                right_shoulder_correct  = right_shoulder_correct    or dist_list[6+base]  <= threshold
+                left_elbow_correct      = left_elbow_correct        or dist_list[7+base]  <= threshold
+                right_elbow_correct     = right_elbow_correct       or dist_list[8+base]  <= threshold
+                left_wrist_correct      = left_wrist_correct        or dist_list[9+base]  <= threshold
+                right_wrist_correct     = right_wrist_correct       or dist_list[10+base] <= threshold
+                left_hip_correct        = left_hip_correct          or dist_list[11+base] <= threshold
+                right_hip_correct       = right_hip_correct         or dist_list[12+base] <= threshold
+                left_knee_correct       = left_knee_correct         or dist_list[13+base] <= threshold
+                right_knee_correct      = right_knee_correct        or dist_list[14+base] <= threshold
+                left_ankle_correct      = left_ankle_correct        or dist_list[15+base] <= threshold
+                right_ankle_correct     = right_ankle_correct       or dist_list[16+base] <= threshold
 
             # Add one to correct keypoint count if any annotation was below threshold for image
             if nose_correct: correct_keypoints["nose"] += 1

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -168,4 +168,40 @@ cocoEval.accumulate()
 
 print('\nSummary: ')
 cocoEval.summarize()
+# %% Run PCK Evaluation
+import imp
+
+import data_generator
+imp.reload(data_generator)
+from data_generator import DataGenerator
+
+import evaluation
+imp.reload(evaluation)
+from evaluation import Evaluation
+
+from constants import *
+import pandas as pd
+
+representative_set_df = pd.read_pickle(os.path.join(DEFAULT_PICKLE_PATH, 'representative_set.pkl'))
+
+subdir = '2021-03-19-23h-46m_batchsize_12_hg_4_subset_0.50_loss_weighted_mse_resume_2021-03-20-23h-48m'
+eval = Evaluation(
+    model_sub_dir = subdir,
+    epoch = 80)
+print("Created Evaluation Instance")
+
+generator = DataGenerator(
+            df=representative_set_df,
+            base_dir=DEFAULT_VAL_IMG_PATH,
+            input_dim=INPUT_DIM,
+            output_dim=OUTPUT_DIM,
+            num_hg_blocks=DEFAULT_NUM_HG,
+            shuffle=False,
+            batch_size=1,
+            online_fetch=True,
+            is_eval=True)
+print("Created DataGenerator Instance\n")
+
+eval.pck_eval(generator, 'output/predictions.json', DEFAULT_VAL_ANNOT_PATH)
+
 # %%

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -144,7 +144,7 @@ generator = DataGenerator(
             is_eval=True)
 print("Created DataGen instance")
 
-image_ids = eval.predict_keypoints(generator, location='output/predictions.json')
+image_ids,_ = eval.predict_keypoints(generator, location='output/predictions.json')
 print('Doneee')
 
 


### PR DESCRIPTION
This PR adds a PCK evaluation metric for more insight into percentage of correct keypoints for each COCO keypoint label.

Example output from the representative set:

Percentage of Correct Key Points (PCK)

Nose:            0.80
Left Eye:        0.60
Right Eye:       0.60
Left Ear:        0.70
Right Ear:       0.80
Left Shoulder:   0.40
Right Shoulder:  0.40
Left Elbow:      0.60
Right Elbow:     0.50
Left Wrist:      0.40
Right Wrist:     0.60
Left Hip:        0.50
Right Hip:       0.50
Left Knee:       0.60
Right Knee:      0.70
Left Ankle:      0.40
Right Ankle:     0.60