### PR TITLE
Fix R/L bug in augmentation pipeline

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -96,3 +96,6 @@ BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 
 # Output filtering constants
 HM_TO_KP_THRESHOLD = 0.2
+
+# Data aug flip R/L probability
+RL_FLIP = 0.5

--- a/data_augmentation.py
+++ b/data_augmentation.py
@@ -1,18 +1,17 @@
 # %% Import required libraries
 # Import utilities
-from util import validate_enum
-from imgaug.augmenters.meta import OneOf
-import numpy as np # linear algebra
 import random
 
 # import the library and helpers
 import imageio
 import imgaug as ia
+import numpy as np  # linear algebra
 from imgaug import augmenters as iaa
 from imgaug.augmentables.kps import Keypoint, KeypointsOnImage
+from imgaug.augmenters.meta import OneOf
 
-from constants import ImageAugmentationStrength
-from constants import RL_FLIP
+from constants import RL_FLIP, ImageAugmentationStrength
+from util import validate_enum
 
 # Holy resources: https://nbviewer.jupyter.org/github/aleju/imgaug-doc/blob/master/notebooks/B01%20-%20Augment%20Keypoints.ipynb
 # Credit to the above notebook for their tutorial on keypoint augmentation

--- a/data_generator.py
+++ b/data_generator.py
@@ -268,7 +268,7 @@ class DataGenerator(Sequence):
                 # Perform data augmentation randomly
                 image_aug, kpsoi_aug = self.augmenter(image=transformed_img, keypoints=kpsoi)
 
-                # Perform a R/L augmentation randomly
+                # Perform a R/L augmentation randomly, applying R/L flip to the labels as well to maintain the right order 
                 image_aug, kpsoi_aug = flipRL(image=image_aug,keypoints=kpsoi_aug)
 
                 # Filter out out-of-bounds (from rotation/cropping) and invalid (originally occluded/not present) keypoints

--- a/data_generator.py
+++ b/data_generator.py
@@ -268,6 +268,9 @@ class DataGenerator(Sequence):
                 # Perform data augmentation randomly
                 image_aug, kpsoi_aug = self.augmenter(image=transformed_img, keypoints=kpsoi)
 
+                # Perform a R/L augmentation randomly
+                image_aug, kpsoi_aug = flipRL(image=image_aug,keypoints=kpsoi_aug)
+
                 # Filter out out-of-bounds (from rotation/cropping) and invalid (originally occluded/not present) keypoints
                 augmented_label = self.convert_imgaug_kpsoi_to_coco_kp(kpsoi_aug, valid, image_aug)
 

--- a/data_generator_tests.py
+++ b/data_generator_tests.py
@@ -67,7 +67,7 @@ from data_generator import DataGenerator
 representative_set_df = pd.read_pickle(os.path.join(DEFAULT_PICKLE_PATH, 'representative_set.pkl'))
 generator = DataGenerator(
     df=representative_set_df,
-    base_dir=DEFAULT_TRAIN_IMG_PATH,
+    base_dir=DEFAULT_VAL_IMG_PATH,
     input_dim=INPUT_DIM,
     output_dim=OUTPUT_DIM,
     num_hg_blocks=DEFAULT_NUM_HG,

--- a/data_generator_tests.py
+++ b/data_generator_tests.py
@@ -92,7 +92,7 @@ print("Batch shape is: ", X_batch.shape, y_batch.shape)
 X, y = X_batch[0], y_batch[0] # take first example of batch
 print("Example shape is: ", X.shape,y.shape)
 
-for i in range(7,8):
+for i in range(NUM_COCO_KEYPOINTS):
   print(COCO_KEYPOINT_LABEL_ARR[i])
   heatmap = y[:,:,i]
   hm = HeatMap(X,heatmap)

--- a/data_generator_tests.py
+++ b/data_generator_tests.py
@@ -56,19 +56,25 @@ def display_img(annId):
   plt.show()
 
 # %% Test the generator
+import pandas as pd
+import data_augmentation
+imp.reload(data_augmentation)
 import data_generator
 imp.reload(data_generator)
 from data_generator import DataGenerator
 
+
+representative_set_df = pd.read_pickle(os.path.join(DEFAULT_PICKLE_PATH, 'representative_set.pkl'))
 generator = DataGenerator(
-    df=val_df,
+    df=representative_set_df,
     base_dir=DEFAULT_TRAIN_IMG_PATH,
     input_dim=INPUT_DIM,
     output_dim=OUTPUT_DIM,
     num_hg_blocks=DEFAULT_NUM_HG,
     shuffle=False,
     batch_size=1,
-    online_fetch=False)
+    online_fetch=False,
+    img_aug_strength=ImageAugmentationStrength.heavy)
 
 # Test the generator
 import time
@@ -79,16 +85,16 @@ pylab.rcParams['figure.figsize'] = (10.0, 10.0)
 from HeatMap import HeatMap # https://github.com/LinShanify/HeatMap
 
 start = time.time()
-X_batch, y_stacked = generator[168]
+X_batch, y_stacked = generator[0]
 print("Retrieving batch took: ",time.time() - start, " s")
 y_batch = y_stacked[0] # take first hourglass section
 print("Batch shape is: ", X_batch.shape, y_batch.shape)
 X, y = X_batch[0], y_batch[0] # take first example of batch
 print("Example shape is: ", X.shape,y.shape)
 
-heatmap = y[:,:,1]
-print(X.max(), X.min(), X.mean())
-print(y.max(), y.min(), y.mean())
-hm = HeatMap(X,heatmap)
-hm.plot(transparency=0.5,show_axis=True,show_colorbar=True)
+for i in range(7,8):
+  print(COCO_KEYPOINT_LABEL_ARR[i])
+  heatmap = y[:,:,i]
+  hm = HeatMap(X,heatmap)
+  hm.plot(transparency=0.5,show_axis=True,show_colorbar=True)
 # %%


### PR DESCRIPTION
When we perform R/L augmentation, a right wrist becomes a left wrist but we do not account for this. Here is an example of the bug before these changes:
With the R/L flip (clearly wrong)
![image](https://user-images.githubusercontent.com/39144350/113335976-8eb9d000-92da-11eb-830b-a079b5e5f45a.png)
Without the R/L flip
![image](https://user-images.githubusercontent.com/39144350/113335962-895c8580-92da-11eb-8d65-629505979dc6.png)

This PR extends the aug pipeline to do custom R/L flip, and reshuffles the kp array accordingly. 