### PR TITLE
Re-enable functionality to run on any user specified image

### DIFF
--- a/HeatMap.py
+++ b/HeatMap.py
@@ -111,4 +111,5 @@ class HeatMap:
         # NOTE that the read image size is too large because of plt's default size.
         heatmap_array = np.array(im)
         buf.close()
+        im.close()
         return heatmap_array

--- a/constants.py
+++ b/constants.py
@@ -115,6 +115,7 @@ PCK_THRESHOLD = 0.2
 # Output save names
 OUTPUT_STACKED_HEATMAP = 'heatmaps'
 OUTPUT_SKELETON = 'skeleton'
+OUTPUT_USER_IMG = 'user_img'
 
 class Generator(Enum):
     train_gen = 0

--- a/constants.py
+++ b/constants.py
@@ -8,6 +8,7 @@ COLAB_TRAINING = False
 # Model Defaults
 DEFAULT_NUM_HG = 4 # NOTE in their final design, 8 were used
 DEFAULT_EPOCHS = 70
+DEFAULT_DATA_BASE_DIR = 'data'
 DEFAULT_MODEL_BASE_DIR = 'models'
 DEFAULT_LOGS_BASE_DIR = 'logs'
 DEFAULT_OUTPUT_BASE_DIR = 'output'

--- a/data_generator.py
+++ b/data_generator.py
@@ -243,6 +243,7 @@ class DataGenerator(Sequence):
                 img, ann['bbox'])
             transformed_label = self.transform_label(
                 ann['keypoints'], cropped_width, cropped_height, anchor_x, anchor_y)
+
             if self.is_eval:
                 metadata = {}
                 metadata["src_set_image_id"] = ann['src_set_image_id']

--- a/evaluation.py
+++ b/evaluation.py
@@ -53,7 +53,7 @@ class Evaluation():
     output shape is (num_hg_blocks, X_batch_size, 64, 64, 17)
     """
     def predict_heatmaps(self, X_batch):
-        return np.array(self.model.predict(X_batch))
+        return np.array(self.model.predict_on_batch(X_batch))
 
     """
     This method has been deprecated in favour of the `visualizeHeatmaps` method in `evaluation_wrapper`

--- a/evaluation.py
+++ b/evaluation.py
@@ -49,16 +49,19 @@ class Evaluation():
     X_batch : {list of ndarrays}
         A list of images which were used as input to the model
 
+    predict_using_flip : {bool}
+        Perform prediction using a flipped version of the input. NOTE the output will be transformed
+        back into the original image coordinate space. Treat this output as you would a normal prediction.
+
     ## Returns:
     output shape is (num_hg_blocks, X_batch_size, 64, 64, 17)
     """
     def predict_heatmaps(self, X_batch, predict_using_flip=False):
         def _predict(X_batch):
+            # Instead of calling model.predict or model.predict_on_batch, we call model by itself.
+            # See https://stackoverflow.com/questions/66271988/warningtensorflow11-out-of-the-last-11-calls-to-triggered-tf-function-retracin
+            # This should fix our memory leak in keras
             return np.array(self.model(X_batch))
-
-        # Instead of calling model.predict or model.predict_on_batch, we call model by itself.
-        # See https://stackoverflow.com/questions/66271988/warningtensorflow11-out-of-the-last-11-calls-to-triggered-tf-function-retracin
-        # This should fix our memory leak in keras
 
         # X_batch has dimensions (batch, x, y, channels)
         # Run both original and flipped image through and average the predictions

--- a/evaluation.py
+++ b/evaluation.py
@@ -52,11 +52,34 @@ class Evaluation():
     ## Returns:
     output shape is (num_hg_blocks, X_batch_size, 64, 64, 17)
     """
-    def predict_heatmaps(self, X_batch):
+    def predict_heatmaps(self, X_batch, predict_using_flip=False):
+        def _predict(X_batch):
+            return np.array(self.model(X_batch))
+
         # Instead of calling model.predict or model.predict_on_batch, we call model by itself.
         # See https://stackoverflow.com/questions/66271988/warningtensorflow11-out-of-the-last-11-calls-to-triggered-tf-function-retracin
         # This should fix our memory leak in keras
-        return np.array(self.model(X_batch))
+
+        # X_batch has dimensions (batch, x, y, channels)
+        # Run both original and flipped image through and average the predictions
+        # Typically increases accuracy by a few percent
+        if predict_using_flip:
+            # Horizontal flip each image in batch
+            X_batch_flipped = X_batch[:,:,::-1,:]
+
+            # Feed flipped image into model
+            # output shape is (num_hg_blocks, X_batch_size, 64, 64, 17)
+            predicted_heatmaps_batch_flipped = _predict(X_batch_flipped)
+
+            # indices to flip order of Left and Right heatmaps [0, 2, 1, 4, 3, 6, 5, 8, 7, etc]
+            reverse_LR_indices = [0] + [2*x-y for x in range(1,9) for y in range(2)]
+
+            # reverse horizontal flip AND reverse left/right heatmaps
+            predicted_heatmaps_batch = predicted_heatmaps_batch_flipped[:,:,:,::-1,reverse_LR_indices]
+        else:
+            predicted_heatmaps_batch = _predict(X_batch)
+
+        return predicted_heatmaps_batch
 
     """
     This method has been deprecated in favour of the `visualizeHeatmaps` method in `evaluation_wrapper`

--- a/evaluation.py
+++ b/evaluation.py
@@ -61,7 +61,7 @@ class Evaluation():
             # Instead of calling model.predict or model.predict_on_batch, we call model by itself.
             # See https://stackoverflow.com/questions/66271988/warningtensorflow11-out-of-the-last-11-calls-to-triggered-tf-function-retracin
             # This should fix our memory leak in keras
-            return np.array(self.model(X_batch))
+            return np.array(self.model.predict_on_batch(X_batch))
 
         # X_batch has dimensions (batch, x, y, channels)
         # Run both original and flipped image through and average the predictions

--- a/evaluation.py
+++ b/evaluation.py
@@ -53,7 +53,10 @@ class Evaluation():
     output shape is (num_hg_blocks, X_batch_size, 64, 64, 17)
     """
     def predict_heatmaps(self, X_batch):
-        return np.array(self.model.predict_on_batch(X_batch))
+        # Instead of calling model.predict or model.predict_on_batch, we call model by itself.
+        # See https://stackoverflow.com/questions/66271988/warningtensorflow11-out-of-the-last-11-calls-to-triggered-tf-function-retracin
+        # This should fix our memory leak in keras
+        return np.array(self.model(X_batch))
 
     """
     This method has been deprecated in favour of the `visualizeHeatmaps` method in `evaluation_wrapper`

--- a/evaluation.py
+++ b/evaluation.py
@@ -155,7 +155,9 @@ class Evaluation():
             X = X_batch[i]
             keypoints = keypoints_batch[i]
             img_id = img_id_batch[i]
-            name = f'{OUTPUT_SKELETON}_{img_id}_{self.epoch}.png'
+            name = f'{img_id}_{self.epoch}.png'
+            if show_skeleton:
+                name = f'{OUTPUT_SKELETON}_{name}'
 
             # Plot predicted keypoints on bounding box image
             x_left = []

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -165,6 +165,13 @@ class EvaluationWrapper():
             # Dimensions are (hourglass_layer, batch, x, y, keypoint)
             keypoints_batch = self.eval.heatmaps_to_keypoints_batch(predicted_heatmaps_batch)
 
+            if average_flip_prediction:
+                # Average predictions from original image and the untransformed flipped image to get a more accurate prediction
+                keypoints_batch_2 = self.eval.predict_heatmaps(X_batch=X_batch, predict_using_flip=True)
+
+                for i in range(predicted_heatmaps_batch.shape[0]):
+                    keypoints_batch[i] = self._average_LR_flip_predictions(keypoints_batch[i], keypoints_batch_2[i])
+
             if visualize_skeleton:
                 # Plot only skeleton
                 img_id_batch_bg = [f'{img_id}_no_bg' for img_id in img_id_batch]

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -17,7 +17,7 @@ from constants import *
 class EvaluationWrapper():
 
     def __init__(self, model_sub_dir, epoch=None, model_base_dir=DEFAULT_MODEL_BASE_DIR):
-        self.update_model(model_sub_dir, epoch=epoch, model_base_dir=DEFAULT_MODEL_BASE_DIR)
+        self.update_model(model_sub_dir, epoch=epoch, model_base_dir=model_base_dir)
 
         representative_set_df = pd.read_pickle(os.path.join(DEFAULT_PICKLE_PATH, 'representative_set.pkl'))
         self.representative_set_gen = data_generator.DataGenerator( df=representative_set_df,

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -173,9 +173,9 @@ class EvaluationWrapper():
             # Plot skeleton with image
             self.eval.visualize_keypoints(X_batch, keypoints_batch, img_id_batch, show_skeleton=visualize_skeleton)
 
-    def _average_LR_flip_predictions(self, prediction1, prediction2):
+    def _average_LR_flip_predictions(self, prediction_1, prediction_2):
         # Average predictions from original image and the untransformed flipped image to get a more accurate prediction
-        output_prediction = prediction1
+        output_prediction = prediction_1
 
         for j in range(NUM_COCO_KEYPOINTS):
             # This code is required so if one version detects the keypoint (x,y,1),
@@ -187,14 +187,14 @@ class EvaluationWrapper():
             y_sum = 0
 
             # Verify visibility flag
-            if prediction1[base+2] == 1:
-                x_sum += prediction1[base]
-                y_sum += prediction1[base + 1]
+            if prediction_1[base+2] == 1:
+                x_sum += prediction_1[base]
+                y_sum += prediction_1[base + 1]
                 n += 1
 
-            if prediction2[base+2] == 1:
-                x_sum += prediction2[base]
-                y_sum += prediction2[base + 1]
+            if prediction_2[base+2] == 1:
+                x_sum += prediction_2[base]
+                y_sum += prediction_2[base + 1]
                 n += 1
 
             # Verify that no division by 0 will occur
@@ -211,16 +211,16 @@ class EvaluationWrapper():
 
     def _full_list_of_predictions_wrapper(self, gen, model_sub_dir, epoch, average_flip_prediction=False):
         print('Predicting over all batches...')
-        image_ids, list_of_predictions = self._full_list_of_predictions(gen, self.model_sub_dir, self.epoch, predict_using_flip=False)
+        image_ids, list_of_predictions = self._full_list_of_predictions(gen, model_sub_dir, epoch, predict_using_flip=False)
         print()
 
         if average_flip_prediction:
             print('Predicting over all batches using a horizontally flipped input, with prediction coordinates transformed back...')
-            image_ids_2, list_of_predictions_2 = self._full_list_of_predictions(gen, self.model_sub_dir, self.epoch, predict_using_flip=True)
+            image_ids_2, list_of_predictions_2 = self._full_list_of_predictions(gen, model_sub_dir, epoch, predict_using_flip=True)
             print()
 
             assert image_ids == image_ids_2, "Expected the image IDs should be in the same order"
-            eps = 1e-3
+
             for i in range(len(list_of_predictions)):
                 # Average predictions from original image and the untransformed flipped image to get a more accurate prediction
                 averaged_predictions = self._average_LR_flip_predictions(list_of_predictions[i]['keypoints'], list_of_predictions_2[i]['keypoints'])

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -215,6 +215,27 @@ class EvaluationWrapper():
 
         return image_ids, list_of_predictions
 
+    """
+    Generates a list of predictions across an entire generator.
+
+    ## Parameters:
+
+    gen : {iterable}
+        Provides X_batch, y_stacked, and metadata_batch data
+
+    model_subdir : {string}
+        Not used, but required for caching purposes
+
+    epoch : {string or int}
+        Not used, but required for caching purposes
+
+    predict_using_flip : {bool}
+        Generate predictions by using a flipped version of the data
+
+    ## Returns:
+
+    A list of predictions in COCO format and corresponding image IDs
+    """
     @lru_cache(maxsize=50)
     def _full_list_of_predictions(self, gen, model_sub_dir, epoch, predict_using_flip=False):
         list_of_predictions = []

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -17,7 +17,7 @@ from constants import *
 class EvaluationWrapper():
 
     def __init__(self, model_sub_dir, epoch=None, model_base_dir=DEFAULT_MODEL_BASE_DIR):
-        self.update_model(model_sub_dir, epoch=None, model_base_dir=DEFAULT_MODEL_BASE_DIR)
+        self.update_model(model_sub_dir, epoch=epoch, model_base_dir=DEFAULT_MODEL_BASE_DIR)
 
         representative_set_df = pd.read_pickle(os.path.join(DEFAULT_PICKLE_PATH, 'representative_set.pkl'))
         self.representative_set_gen = data_generator.DataGenerator( df=representative_set_df,

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -246,24 +246,9 @@ class EvaluationWrapper():
             X_batch, _, metadata_batch = gen[i]
 
             # X_batch has dimensions (batch, x, y, channels)
-            # Run both original and flipped image through and average the predictions
+            # If predict_using_flip, run both original and flipped image through and average the predictions
             # Typically increases accuracy by a few percent
-            if predict_using_flip:
-                # Copy by reference NOTE X_batch is modified __in place__
-                # Horizontal flip each image in batch
-                X_batch_flipped = X_batch[:,:,::-1,:]
-
-                # Feed flipped image into model
-                # output shape is (num_hg_blocks, X_batch_size, 64, 64, 17)
-                predicted_heatmaps_batch_flipped = self.eval.predict_heatmaps(X_batch_flipped)
-
-                # indices to flip order of Left and Right heatmaps [0, 2, 1, 4, 3, 6, 5, 8, 7, etc]
-                reverse_LR_indices = [0] + [2*x-y for x in range(1,9) for y in range(2)]
-
-                # reverse horizontal flip AND reverse left/right heatmaps
-                predicted_heatmaps_batch = predicted_heatmaps_batch_flipped[:,:,:,::-1,reverse_LR_indices]
-            else:
-                predicted_heatmaps_batch = self.eval.predict_heatmaps(X_batch)
+            predicted_heatmaps_batch = self.eval.predict_heatmaps(X_batch=X_batch, predict_using_flip=predict_using_flip)
 
             imgs, predictions = self.eval.heatmap_to_COCO_format(predicted_heatmaps_batch, metadata_batch)
             list_of_predictions += predictions

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -267,5 +267,7 @@ class EvaluationWrapper():
             gen = self.representative_set_gen
         elif genEnum == Generator.val_gen:
             gen = self.val_gen
+        else:
+            gen = None
 
         return gen

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -85,7 +85,7 @@ class EvaluationWrapper():
                 if imghdr.what(filepath) is not None:
                     image_paths.append(filepath)
         elif os.path.isfile(path):
-            image_paths += path
+            image_paths.append(path)
         else:
             # It is a special file (socket, FIFO, device file)
             raise ValueError('Invalid path provided')

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -73,6 +73,34 @@ class EvaluationWrapper():
 
         self.eval = evaluation.Evaluation(model_base_dir=model_base_dir, model_sub_dir=model_sub_dir, epoch=self.epoch)
 
+    def predict_on_image(self, img_path, img_id, visualize_skeleton=True):
+        # Number of hg blocks doesn't matter
+        X_batch, y_stacked = evaluation.load_and_preprocess_img(img_path, 1)
+
+        img_id_batch = [img_id]
+
+        # y_batch = y_stacked[0] # take first hourglass section
+        # X, y = X_batch[0], y_batch[0] # take first example of batch
+
+        # Get predicted heatmaps for image
+        predicted_heatmaps_batch = self.eval.predict_heatmaps(X_batch)
+
+        # Get predicted keypoints from last hourglass (last element of list)
+        # Dimensions are (hourglass_layer, batch, x, y, keypoint)
+        keypoints_batch = self.eval.heatmaps_to_keypoints_batch(predicted_heatmaps_batch)
+
+        # Get predicted keypoints from last hourglass (last element of list)
+        # Dimensions are (hourglass_layer, batch, x, y, keypoint)
+        keypoints_batch = self.eval.heatmaps_to_keypoints_batch(predicted_heatmaps_batch)
+
+        if visualize_skeleton:
+            # Plot only skeleton
+            img_id_batch_bg = [f'{img_id}_no_bg' for img_id in img_id_batch]
+            self.eval.visualize_keypoints(np.zeros(X_batch.shape), keypoints_batch, img_id_batch_bg, show_skeleton=visualize_skeleton)
+
+        # Plot skeleton with image
+        self.eval.visualize_keypoints(X_batch, keypoints_batch, img_id_batch, show_skeleton=visualize_skeleton)
+
     def visualizeHeatmaps(self, genEnum=Generator.representative_set_gen):
         self.visualize(genEnum=genEnum, visualize_heatmaps=True, visualize_scatter=False, visualize_skeleton=False)
 
@@ -104,7 +132,7 @@ class EvaluationWrapper():
                 if visualize_skeleton:
                     # Plot only skeleton
                     img_id_batch_bg = [f'{img_id}_no_bg' for img_id in img_id_batch]
-                    self.eval.visualize_keypoints(np.zeros(X_batch.shape), keypoints_batch, img_id_batch_bg)
+                    self.eval.visualize_keypoints(np.zeros(X_batch.shape), keypoints_batch, img_id_batch_bg, show_skeleton=visualize_skeleton)
 
                 # Plot skeleton with image
                 self.eval.visualize_keypoints(X_batch, keypoints_batch, img_id_batch, show_skeleton=visualize_skeleton)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ matplotlib
 numpy==1.17.0
 requests
 pycocotools @ git+https://github.com/philferriere/cocoapi.git@2929bd2ef6b451054755dfd7ceb09278f935f7ad#subdirectory=PythonAPI
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ h5py==2.10.0
 opencv-contrib-python==4.4.0.42
 opencv-python==4.4.0.42
 matplotlib
+pandas
+Pillow
 numpy==1.17.0
 requests
 pycocotools @ git+https://github.com/philferriere/cocoapi.git@2929bd2ef6b451054755dfd7ceb09278f935f7ad#subdirectory=PythonAPI
-pandas

--- a/run_refactored_eval.py
+++ b/run_refactored_eval.py
@@ -60,6 +60,6 @@ user_img_dir = 'user_img'
 
 img_path = os.path.join(constants.DEFAULT_DATA_BASE_DIR, user_img_dir, img_name)
 
-eval.predict_on_image(img_path, name_no_extension, average_flip_prediction=False)
-eval.predict_on_image(img_path, name_no_extension + '_flip', average_flip_prediction=True)
+eval.predict_on_path(img_path, average_flip_prediction=False)
+eval.predict_on_path(img_path, average_flip_prediction=True)
 # %%

--- a/run_refactored_eval.py
+++ b/run_refactored_eval.py
@@ -60,6 +60,6 @@ user_img_dir = 'user_img'
 
 img_path = os.path.join(constants.DEFAULT_DATA_BASE_DIR, user_img_dir, img_name)
 
-eval.predict_on_image(img_path, name_no_extension)
+eval.predict_on_image(img_path, name_no_extension, average_flip_prediction=False)
 eval.predict_on_image(img_path, name_no_extension + '_flip', average_flip_prediction=True)
 # %%

--- a/run_refactored_eval.py
+++ b/run_refactored_eval.py
@@ -53,11 +53,13 @@ eval.visualizeKeypoints(constants.Generator.representative_set_gen)
 
 elapsed = time.time() - start
 print("Total keypoint time: {}".format(str(timedelta(seconds=elapsed))))
-# %%
+# %% Run on arbitrary images
 img_name = 'IMG_3320.JPG'
 name_no_extension = img_name.split('.')[0]
+user_img_dir = 'user_img'
 
-img_path = os.path.join(constants.DEFAULT_DATA_BASE_DIR, img_name)
+img_path = os.path.join(constants.DEFAULT_DATA_BASE_DIR, user_img_dir, img_name)
 
 eval.predict_on_image(img_path, name_no_extension)
+eval.predict_on_image(img_path, name_no_extension + '_flip', average_flip_prediction=True)
 # %%

--- a/run_refactored_eval.py
+++ b/run_refactored_eval.py
@@ -63,3 +63,6 @@ img_path = os.path.join(constants.DEFAULT_DATA_BASE_DIR, user_img_dir, img_name)
 eval.predict_on_path(img_path, average_flip_prediction=False)
 eval.predict_on_path(img_path, average_flip_prediction=True)
 # %%
+eval.predict_on_path(os.path.join(constants.DEFAULT_DATA_BASE_DIR, user_img_dir), average_flip_prediction=False)
+eval.predict_on_path(os.path.join(constants.DEFAULT_DATA_BASE_DIR, user_img_dir), average_flip_prediction=True)
+# %%

--- a/run_refactored_eval.py
+++ b/run_refactored_eval.py
@@ -1,4 +1,5 @@
 # %% Create Eval Instance
+import os
 import time
 from datetime import datetime, timedelta
 
@@ -52,4 +53,11 @@ eval.visualizeKeypoints(constants.Generator.representative_set_gen)
 
 elapsed = time.time() - start
 print("Total keypoint time: {}".format(str(timedelta(seconds=elapsed))))
+# %%
+img_name = 'IMG_3320.JPG'
+name_no_extension = img_name.split('.')[0]
+
+img_path = os.path.join(constants.DEFAULT_DATA_BASE_DIR, img_name)
+
+eval.predict_on_image(img_path, name_no_extension)
 # %%

--- a/util.py
+++ b/util.py
@@ -49,6 +49,21 @@ def get_highest_epoch_file(model_base_dir, model_subdir):
 
     return highest_epoch
 
+def get_all_epochs(model_base_dir, model_subdir):
+    enclosing_dir = os.path.join(model_base_dir, model_subdir)
+
+    files = os.listdir(enclosing_dir)
+
+    model_saved_weights = {}
+    for f in files:
+        match = re.match(MODEL_CHECKPOINT_REGEX, f)
+
+        if match:
+            epoch = int(match.group(1))
+            model_saved_weights[epoch] = f
+
+    return model_saved_weights
+
 def find_resume_json_weights_str(model_base_dir, model_subdir, resume_epoch):
     enclosing_dir = os.path.join(model_base_dir, model_subdir)
 


### PR DESCRIPTION
Updated: This PR re-enables functionality to run on any specified image or file directory. It also adds the ability to average predictions from normal and horizontally flipped images to achieve higher accuracy.

TODO:
Surface image as variable instead of saving it as file