### PR TITLE
Fix bug where finding the max heatmap location after non-maximum suppression returned empty list

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -111,7 +111,7 @@ BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 # Output filtering constants
 HM_TO_KP_THRESHOLD = 0.2
 PCK_THRESHOLD = 0.2
-DEFAULT_PCK_THRESHOLD = 10
+DEFAULT_PCK_THRESHOLD = 5
 
 # Output save names
 OUTPUT_STACKED_HEATMAP = 'heatmaps'

--- a/constants.py
+++ b/constants.py
@@ -110,6 +110,8 @@ BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 
 # Output filtering constants
 HM_TO_KP_THRESHOLD = 0.2
+HM_TO_KP_THRESHOLD_POST_FILTER = HM_TO_KP_THRESHOLD / 5
+
 PCK_THRESHOLD = 0.2
 # This default PCK threshold is used when either hip is not present.
 # It is empirically chosen by taking the mean torso width in the validation set

--- a/constants.py
+++ b/constants.py
@@ -111,7 +111,10 @@ BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 # Output filtering constants
 HM_TO_KP_THRESHOLD = 0.2
 PCK_THRESHOLD = 0.2
-DEFAULT_PCK_THRESHOLD = 5
+# This default PCK threshold is used when either hip is not present.
+# It is empirically chosen by taking the mean torso width in the validation set
+# {'mean': 25.273791558055517, 'std': 19.27466898776274}
+DEFAULT_PCK_THRESHOLD = PCK_THRESHOLD * 25
 
 # Output save names
 OUTPUT_STACKED_HEATMAP = 'heatmaps'

--- a/constants.py
+++ b/constants.py
@@ -111,6 +111,7 @@ BBOX_MIN_SIZE = 900 # Filter out images smaller than 30x30, TODO tweak
 # Output filtering constants
 HM_TO_KP_THRESHOLD = 0.2
 PCK_THRESHOLD = 0.2
+DEFAULT_PCK_THRESHOLD = 10
 
 # Output save names
 OUTPUT_STACKED_HEATMAP = 'heatmaps'

--- a/evaluation.py
+++ b/evaluation.py
@@ -324,6 +324,8 @@ class Evaluation():
 
                     # TODO figure out what to do if a hip isn't present
                     threshold = DEFAULT_PCK_THRESHOLD
+
+                    # If both hips are present
                     if annotation_keypoints[35] > 0 and annotation_keypoints[38] > 0:
                         left_hip_point = np.array(annotation_keypoints[33], annotation_keypoints[34])
                         right_hip_point = np.array(annotation_keypoints[36], annotation_keypoints[37])

--- a/evaluation.py
+++ b/evaluation.py
@@ -323,10 +323,15 @@ class Evaluation():
 
                     # Calculate PCK@0.2 threshold for image
                     # Joint at 11 is left hip, Joint at 12 is right hip. Multiply by 3 as each keypoint has (x, y, visibility) to get the array index
-                    left_hip_point = np.array(annotation_keypoints[33], annotation_keypoints[34])
-                    right_hip_point = np.array(annotation_keypoints[36], annotation_keypoints[37])
-                    torso = np.linalg.norm(left_hip_point-right_hip_point)
-                    threshold = PCK_THRESHOLD*torso
+
+                    # TODO figure out what to do if a hip isn't present
+                    threshold = DEFAULT_PCK_THRESHOLD
+                    if annotation_keypoints[35] > 0 and annotation_keypoints[38] > 0:
+                        left_hip_point = np.array(annotation_keypoints[33], annotation_keypoints[34])
+                        right_hip_point = np.array(annotation_keypoints[36], annotation_keypoints[37])
+                        torso = np.linalg.norm(left_hip_point-right_hip_point)
+                        threshold = PCK_THRESHOLD*torso
+                        print(f'Torso: {torso},\tthreshold: {threshold}')
 
                     for i in range(NUM_COCO_KEYPOINTS):
                         base = i * NUM_COCO_KP_ATTRBS

--- a/evaluation.py
+++ b/evaluation.py
@@ -231,7 +231,7 @@ class Evaluation():
             # and get its coordinates and confidence
             y, x = np.unravel_index(np.argmax(peaks), peaks.shape)
 
-            if peaks[y, x] > HM_TO_KP_THRESHOLD:
+            if peaks[y, x] > HM_TO_KP_THRESHOLD / 5:
                 conf = peaks[y, x]
             else:
                 x, y, conf = 0, 0, 0

--- a/evaluation.py
+++ b/evaluation.py
@@ -229,9 +229,9 @@ class Evaluation():
 
             # Choose the max point in heatmap (we only pick 1 keypoint in each heatmap)
             # and get its coordinates and confidence
-            y, x = np.where(peaks == peaks.max())
+            y, x = np.unravel_index(np.argmax(peaks), peaks.shape)
 
-            if int(x[0]) > 0 and int(y[0]) > 0:
+            if peaks[y_new, x_new] > HM_TO_KP_THRESHOLD:
                 x_new = int(x[0])
                 y_new = int(y[0])
                 conf_new = peaks[y_new, x_new]

--- a/evaluation.py
+++ b/evaluation.py
@@ -231,7 +231,10 @@ class Evaluation():
             # and get its coordinates and confidence
             y, x = np.unravel_index(np.argmax(peaks), peaks.shape)
 
-            if peaks[y, x] > HM_TO_KP_THRESHOLD / 5:
+            # reduce threshold since non-maximum suppression may have reduced the maximum value
+            # values below this threshold have already been suppressed to zero so this shouldnt
+            # affect the conversion of heatmap to keypoint
+            if peaks[y, x] > HM_TO_KP_THRESHOLD_POST_FILTER:
                 conf = peaks[y, x]
             else:
                 x, y, conf = 0, 0, 0
@@ -318,7 +321,6 @@ class Evaluation():
                     annotation_keypoints = data['annotations'][i]['keypoints']
                     prediction_keypoints = np.array(prediction_keypoints)
                     annotation_keypoints = np.array(annotation_keypoints)
-
 
                     # Calculate PCK@0.2 threshold for image
                     # TODO figure out what to do if a hip isn't present

--- a/evaluation.py
+++ b/evaluation.py
@@ -319,13 +319,13 @@ class Evaluation():
                     prediction_keypoints = np.array(prediction_keypoints)
                     annotation_keypoints = np.array(annotation_keypoints)
 
-                    # Calculate PCK@0.2 threshold for image
-                    # Joint at 11 is left hip, Joint at 12 is right hip. Multiply by 3 as each keypoint has (x, y, visibility) to get the array index
 
+                    # Calculate PCK@0.2 threshold for image
                     # TODO figure out what to do if a hip isn't present
                     threshold = DEFAULT_PCK_THRESHOLD
 
                     # If both hips are present
+                    # Joint at 11 is left hip, Joint at 12 is right hip. Multiply by 3 as each keypoint has (x, y, visibility) to get the array index
                     if annotation_keypoints[35] > 0 and annotation_keypoints[38] > 0:
                         left_hip_point = np.array(annotation_keypoints[33], annotation_keypoints[34])
                         right_hip_point = np.array(annotation_keypoints[36], annotation_keypoints[37])

--- a/evaluation.py
+++ b/evaluation.py
@@ -331,7 +331,6 @@ class Evaluation():
                         right_hip_point = np.array(annotation_keypoints[36], annotation_keypoints[37])
                         torso = np.linalg.norm(left_hip_point-right_hip_point)
                         threshold = PCK_THRESHOLD*torso
-                        print(f'Torso: {torso},\tthreshold: {threshold}')
 
                     for i in range(NUM_COCO_KEYPOINTS):
                         base = i * NUM_COCO_KP_ATTRBS

--- a/evaluation.py
+++ b/evaluation.py
@@ -231,16 +231,14 @@ class Evaluation():
             # and get its coordinates and confidence
             y, x = np.unravel_index(np.argmax(peaks), peaks.shape)
 
-            if peaks[y_new, x_new] > HM_TO_KP_THRESHOLD:
-                x_new = int(x[0])
-                y_new = int(y[0])
-                conf_new = peaks[y_new, x_new]
+            if peaks[y, x] > HM_TO_KP_THRESHOLD:
+                conf = peaks[y, x]
             else:
-                x_new, y_new, conf_new = 0, 0, 0
+                x, y, conf = 0, 0, 0
 
-            keypoints[i, 0] = x_new
-            keypoints[i, 1] = y_new
-            keypoints[i, 2] = conf_new
+            keypoints[i, 0] = x
+            keypoints[i, 1] = y
+            keypoints[i, 2] = conf
 
         return keypoints
 

--- a/evaluation_wrapper.py
+++ b/evaluation_wrapper.py
@@ -165,7 +165,8 @@ class EvaluationWrapper():
     def calculateMetric(self, metric, epochs, genEnum, average_flip_prediction=False):
         gen = self._get_generator(genEnum)
         for i, epoch in enumerate(epochs):
-            util.print_progress_bar(1.0*i/len(epochs), label=f"Epoch {epoch}/{epochs[-1]}")
+            util.print_progress_bar(1.0*i/len(epochs), label=f"Epoch {epoch}. Completed {i}/{len(epochs)}")
+            print('\n')
             if self.epoch != epoch:
                 self.update_model(self.model_sub_dir, epoch=epoch, model_base_dir=DEFAULT_MODEL_BASE_DIR)
             image_ids, list_of_predictions = self._full_list_of_predictions_wrapper(gen, self.model_sub_dir, self.epoch, average_flip_prediction=average_flip_prediction)

--- a/run_eval.py
+++ b/run_eval.py
@@ -18,13 +18,15 @@ eval = evaluation_wrapper.EvaluationWrapper('2021-04-03-18h-11m_batchsize_16_hg_
 # %% Run OKS
 start = time.time()
 
-eval.calculateOKS(1, constants.Generator.representative_set_gen, average_flip_prediction=True)
+epochs = [x for x in range(1,6)] + [10*x for x in range(1,8)]
+
+eval.calculateMetric(constants.Metrics.oks, epochs, constants.Generator.representative_set_gen, average_flip_prediction=False)
 elapsed = time.time() - start
 print("Total OKS average normal & flip time: {}".format(str(timedelta(seconds=elapsed))))
 
 start = time.time()
 
-eval.calculateOKS(1, constants.Generator.representative_set_gen, average_flip_prediction=False)
+eval.calculateMetric(constants.Metrics.oks, epochs, constants.Generator.representative_set_gen, average_flip_prediction=True)
 
 elapsed = time.time() - start
 print("Total OKS time: {}".format(str(timedelta(seconds=elapsed))))
@@ -32,8 +34,9 @@ print("Total OKS time: {}".format(str(timedelta(seconds=elapsed))))
 # %% Run PCK
 start = time.time()
 
-eval.calculatePCK(1, constants.Generator.representative_set_gen, average_flip_prediction=True)
-eval.calculatePCK(1, constants.Generator.representative_set_gen, average_flip_prediction=False)
+eval.calculateMetric(constants.Metrics.pck, epochs, constants.Generator.val_gen, average_flip_prediction=False)
+
+eval.calculateMetric(constants.Metrics.pck, epochs, constants.Generator.val_gen, average_flip_prediction=True)
 
 elapsed = time.time() - start
 print("Total PCK time: {}".format(str(timedelta(seconds=elapsed))))


### PR DESCRIPTION
`np.where(peaks == peaks.max())` was returning an empty list for some reason. I suspect it is due to floating point equality comparison.

This PR uses a more robust way that guarantees that a result will be returned.

I've also looked into partially patching `PCK`.